### PR TITLE
HRIN-463: Updated field type, widget and formatter ids

### DIFF
--- a/config/sync/core.entity_form_display.node.public_meeting.default.yml
+++ b/config/sync/core.entity_form_display.node.public_meeting.default.yml
@@ -173,13 +173,13 @@ content:
     weight: 17
     settings: {  }
     third_party_settings: {  }
-    type: pretix_date_widget_type
+    type: pretix_date_widget
     region: content
   field_pretix_event_settings:
     weight: 18
     settings: {  }
     third_party_settings: {  }
-    type: pretix_event_settings_widget_type
+    type: pretix_event_settings_widget
     region: content
   field_project_reference:
     weight: 8

--- a/config/sync/core.entity_view_display.node.public_meeting.default.yml
+++ b/config/sync/core.entity_view_display.node.public_meeting.default.yml
@@ -199,7 +199,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: pretix_date_formatter_type
+    type: pretix_date_formatter
     region: footer
   field_registration_deadline:
     type: datetime_plain

--- a/config/sync/core.entity_view_display.node.public_meeting.teaser.yml
+++ b/config/sync/core.entity_view_display.node.public_meeting.teaser.yml
@@ -79,7 +79,7 @@ content:
       link: false
     third_party_settings: {  }
   field_pretix_dates:
-    type: pretix_date_formatter_type
+    type: pretix_date_formatter
     weight: 5
     region: content
     label: hidden

--- a/config/sync/field.field.node.public_meeting.field_pretix_dates.yml
+++ b/config/sync/field.field.node.public_meeting.field_pretix_dates.yml
@@ -18,4 +18,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: pretix_date_field_type
+field_type: pretix_date

--- a/config/sync/field.field.node.public_meeting.field_pretix_event_settings.yml
+++ b/config/sync/field.field.node.public_meeting.field_pretix_event_settings.yml
@@ -18,4 +18,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: pretix_event_settings_field_type
+field_type: pretix_event_settings

--- a/config/sync/field.storage.node.field_pretix_dates.yml
+++ b/config/sync/field.storage.node.field_pretix_dates.yml
@@ -8,7 +8,7 @@ dependencies:
 id: node.field_pretix_dates
 field_name: field_pretix_dates
 entity_type: node
-type: pretix_date_field_type
+type: pretix_date
 settings: {  }
 module: itk_pretix
 locked: false

--- a/config/sync/field.storage.node.field_pretix_event_settings.yml
+++ b/config/sync/field.storage.node.field_pretix_event_settings.yml
@@ -8,7 +8,7 @@ dependencies:
 id: node.field_pretix_event_settings
 field_name: field_pretix_event_settings
 entity_type: node
-type: pretix_event_settings_field_type
+type: pretix_event_settings
 settings: {  }
 module: itk_pretix
 locked: false

--- a/web/modules/custom/hoeringsportal_public_meeting/hoeringsportal_public_meeting.module
+++ b/web/modules/custom/hoeringsportal_public_meeting/hoeringsportal_public_meeting.module
@@ -23,10 +23,10 @@ function hoeringsportal_public_meeting_node_presave(NodeInterface $node) {
     $pretix_field = $node->hasField($pretix_field_name) ? $node->get($pretix_field_name) : NULL;
     $first_meeting = $node->hasField($first_meeting_field_name) ? $node->get($first_meeting_field_name) : NULL;
     $last_meeting = $node->hasField($last_meeting_field_name) ? $node->get($last_meeting_field_name) : NULL;
-    if ($node->get('field_signup_selection')->getValue() == 'pretix') {
+    if ('pretix' === $node->field_signup_selection->value) {
       if ($pretix_field) {
         $pretix_type = $pretix_field->getFieldDefinition()->getType();
-        if ($pretix_type == 'pretix_date_field_type') {
+        if ($pretix_type == 'pretix_date') {
           if ($first_meeting && $last_meeting) {
             $values = $pretix_field->getValue();
             // Set a comparable value for first_time possible.
@@ -118,4 +118,3 @@ function hoeringsportal_public_meeting_last_meeting_validate($element, FormState
     }
   }
 }
-


### PR DESCRIPTION
https://jira.itkdev.dk/browse/HRIN-463

Updates config to match changes in https://github.com/itk-dev/itk_pretix_d8/pull/12.

A manual update of the database is required to make everything work after doing this (the lazy programmer hasn't yet added update hooks):

```sql
update config set data = replace(data, 's:22:"pretix_date_field_type"', 's:11:"pretix_date"') where data like '%s:22:"pretix_date_field_type"%'\G
update config set data = replace(data, 's:32:"pretix_event_settings_field_type"', 's:21:"pretix_event_settings"') where data like '%s:32:"pretix_event_settings_field_type"%'\G

update key_value set value = replace(value, 's:22:"pretix_date_field_type"', 's:11:"pretix_date"') where value like '%s:22:"pretix_date_field_type"%'\G
update key_value set value = replace(value, 's:32:"pretix_event_settings_field_type"', 's:21:"pretix_event_settings"') where value like '%s:32:"pretix_event_settings_field_type"%'\G
```

