### PR TITLE
HRIN-471: Updated handling of pretix dates

### DIFF
--- a/web/modules/custom/hoeringsportal_public_meeting/hoeringsportal_public_meeting.module
+++ b/web/modules/custom/hoeringsportal_public_meeting/hoeringsportal_public_meeting.module
@@ -5,7 +5,6 @@
  * Module for public meeting content type.
  */
 
-use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -29,22 +28,20 @@ function hoeringsportal_public_meeting_node_presave(NodeInterface $node) {
         $pretix_type = $pretix_field->getFieldDefinition()->getType();
         if ($pretix_type == 'pretix_date') {
           if ($first_meeting && $last_meeting) {
-            $values = $pretix_field->getValue();
-            // Only act if values were found.
-            if ($values) {
-              // Set a comparable value for first_time possible.
-              $first_time = $values[0]['time_from'];
-              $last_time = new DrupalDateTime('2001-01-01');
-              // Determine latest possible value.
-              foreach ($values as $value) {
-                if ($value['time_from'] < $first_time) {
-                  $first_time = $value['time_from'];
+            if ($pretix_field->count() > 0) {
+              $first_time = NULL;
+              $last_time = NULL;
+              /** @var \Drupal\itk_pretix\Plugin\Field\FieldType\PretixDate $date */
+              foreach ($pretix_field as $date) {
+                if (NULL === $first_time || $date->time_from < $first_time) {
+                  $first_time = $date->time_from;
                 }
 
-                if ($value['time_to'] > $last_time) {
-                  $last_time = $value['time_to'];
+                if (NULL === $last_time || $date->time_to > $last_time) {
+                  $last_time = $date->time_to;
                 }
               }
+
               $format = DateTimeItemInterface::DATETIME_STORAGE_FORMAT;
               $node->set($first_meeting_field_name, $first_time->format($format, ['timezone' => 'UTC']));
               $node->set($last_meeting_field_name, $last_time->format($format, ['timezone' => 'UTC']));


### PR DESCRIPTION
https://jira.itkdev.dk/browse/HRIN-471

Depends on changes in https://github.com/itk-dev/itk_pretix_d8/pull/15 and manually updating the database:

```sql
/* Create new date columns */
ALTER TABLE node__field_pretix_dates
 ADD COLUMN field_pretix_dates_time_from_value VARCHAR(20) NOT NULL,
 ADD COLUMN field_pretix_dates_time_to_value VARCHAR(20) NOT NULL;

ALTER TABLE node_revision__field_pretix_dates
 ADD COLUMN field_pretix_dates_time_from_value VARCHAR(20) NOT NULL,
 ADD COLUMN field_pretix_dates_time_to_value VARCHAR(20) NOT NULL;

/* Copy date values */
UPDATE node__field_pretix_dates
   SET field_pretix_dates_time_from_value = REPLACE(SUBSTRING(CONVERT_TZ(SUBSTRING(field_pretix_dates_time_from, 1, 19), SUBSTRING(field_pretix_dates_time_from, 21), 'UTC'), 1, 19), ' ', 'T'),
       field_pretix_dates_time_to_value = REPLACE(SUBSTRING(CONVERT_TZ(SUBSTRING(field_pretix_dates_time_to, 1, 19), SUBSTRING(field_pretix_dates_time_to, 21), 'UTC'), 1, 19), ' ', 'T');

UPDATE node_revision__field_pretix_dates
   SET field_pretix_dates_time_from_value = REPLACE(SUBSTRING(CONVERT_TZ(SUBSTRING(field_pretix_dates_time_from, 1, 19), SUBSTRING(field_pretix_dates_time_from, 21), 'UTC'), 1, 19), ' ', 'T'),
       field_pretix_dates_time_to_value = REPLACE(SUBSTRING(CONVERT_TZ(SUBSTRING(field_pretix_dates_time_to, 1, 19), SUBSTRING(field_pretix_dates_time_to, 21), 'UTC'), 1, 19), ' ', 'T');

/* Drop old date columns */
ALTER TABLE node__field_pretix_dates
DROP COLUMN field_pretix_dates_time_from,
DROP COLUMN field_pretix_dates_time_to;

ALTER TABLE node_revision__field_pretix_dates
DROP COLUMN field_pretix_dates_time_from,
DROP COLUMN field_pretix_dates_time_to;
```