### PR TITLE
HRIN-671: Updated entity_browser module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "drupal/ds": "^3.1",
         "drupal/email_registration": "^1.0@RC",
         "drupal/entity": "^1.2",
-        "drupal/entity_browser": "^1.5",
+        "drupal/entity_browser": "^2.6",
         "drupal/entityqueue": "^1.0@alpha",
         "drupal/field_group": "^3.0",
         "drupal/flag": "^4.0@alpha",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b68fcf4b5d7f2eb8a1515050f7ba945",
+    "content-hash": "ad0a4d42fb2277e779b3dd416f2c5f67",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2779,36 +2779,35 @@
         },
         {
             "name": "drupal/entity_browser",
-            "version": "1.10.0",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/entity_browser.git",
-                "reference": "8.x-1.10"
+                "reference": "8.x-2.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/entity_browser-8.x-1.10.zip",
-                "reference": "8.x-1.10",
-                "shasum": "1a6b9f293f4763759fee2362ed7566f270829356"
+                "url": "https://ftp.drupal.org/files/projects/entity_browser-8.x-2.6.zip",
+                "reference": "8.x-2.6",
+                "shasum": "95cad4ce9620ccb4f02afa0e8b8bbf7c73fc5aac"
             },
             "require": {
-                "drupal/core": "^8.7.7 || ^9"
+                "drupal/core": "^8.8 || ^9"
             },
             "require-dev": {
                 "drupal/embed": "~1.0",
-                "drupal/entity": "~1.0",
-                "drupal/entity_embed": "~1.0",
-                "drupal/entityqueue": "~1.0",
-                "drupal/inline_entity_form": "~1.0",
-                "drupal/media_entity": "~1.0",
-                "drupal/paragraphs": "~1.0",
+                "drupal/entity_embed": "1.x-dev",
+                "drupal/entity_reference_revisions": "1.x-dev",
+                "drupal/entityqueue": "1.x-dev",
+                "drupal/inline_entity_form": "1.x-dev",
+                "drupal/paragraphs": "1.x-dev",
                 "drupal/token": "~1.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.10",
-                    "datestamp": "1579563787",
+                    "version": "8.x-2.6",
+                    "datestamp": "1624401306",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
https://jira.itkdev.dk/browse/HRIN-671

Fixes

```
Drupal\Core\Security\UntrustedCallbackException: Render #post_render callbacks must be methods of a class that implements \Drupal\Core\Security\TrustedCallbackInterface or be an anonymous function. The callback was Drupal\entity_browser\Plugin\views\display\EntityBrowser::postRender. See https://www.drupal.org/node/2966725 in Drupal\Core\Render\Renderer->doTrustedCallback() (line 96 of core/lib/Drupal/Core/Security/DoTrustedCallbackTrait.php). 
```

(cf. https://www.drupal.org/node/2966725)

See “8.x-2.x branch information” on https://www.drupal.org/project/entity_browser.


