### PR TITLE
HRIN-700: Stored Deskpro languages in local config

### DIFF
--- a/web/modules/custom/hoeringsportal_deskpro/src/Service/DeskproService.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/Service/DeskproService.php
@@ -507,6 +507,20 @@ class DeskproService {
   }
 
   /**
+   * Get ticket languages.
+   */
+  public function getTicketLanguages() {
+    return $this->config->getTicketLanguages();
+  }
+
+  /**
+   * Get default ticket language.
+   */
+  public function getDefaultTicketLanguage() {
+    return $this->config->getDefaultTicketLanguage();
+  }
+
+  /**
    * Simple per request response cache.
    *
    * @var array

--- a/web/modules/custom/hoeringsportal_deskpro/src/Service/HearingHelper.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/Service/HearingHelper.php
@@ -257,20 +257,13 @@ class HearingHelper {
    * Get Deskpro language id for a hearing.
    */
   private function getLanguageId(NodeInterface $node) {
-    try {
-      $response = $this->deskpro->getLanguages();
-
-      $locale = $node->language()->getId();
-      foreach ($response->getData() as $language) {
-        if ($language['locale'] === $locale) {
-          return $language['id'];
-        }
-      }
-    }
-    catch (\Exception $exception) {
+    $ticketLanguages = $this->deskpro->getTicketLanguages();
+    $locale = $node->language()->getId();
+    if (isset($ticketLanguages[$locale])) {
+      return (int) $ticketLanguages[$locale];
     }
 
-    return 1;
+    return (int) ($this->deskpro->getDefaultTicketLanguage() ?? 1);
   }
 
   /**

--- a/web/modules/custom/hoeringsportal_deskpro/src/State/DeskproConfig.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/State/DeskproConfig.php
@@ -157,4 +157,18 @@ class DeskproConfig extends DatabaseStorage {
     return \Drupal::config('hoeringsportal_deskpro.config')->get('deskpro_hearing_id_prefix');
   }
 
+  /**
+   * Get ticket languages.
+   */
+  public function getTicketLanguages() {
+    return $this->get('deskpro_languages', [])['ticket_languages'] ?? [];
+  }
+
+  /**
+   * Get default ticket language.
+   */
+  public function getDefaultTicketLanguage() {
+    return $this->get('deskpro_languages', [])['default_ticket_language'] ?? NULL;
+  }
+
 }


### PR DESCRIPTION
https://jira.itkdev.dk/browse/HRIN-700

Stores Deskpro languages in local config rather than getting it from the Deskpro API whenever a new ticket is added.
