### PR TITLE
Fix update hook

### DIFF
--- a/web/modules/custom/hoeringsportal_citizen_proposal/hoeringsportal_citizen_proposal.install
+++ b/web/modules/custom/hoeringsportal_citizen_proposal/hoeringsportal_citizen_proposal.install
@@ -168,5 +168,9 @@ function hoeringsportal_citizen_proposal_update_9002(): void {
     'default' => '',
   ];
   $schema->changeField($table_name, $old_field_name, $new_field_name, $spec);
-  $schema->addIndex($table_name, $new_field_name, [$new_field_name], hoeringsportal_citizen_proposal_schema()[$table_name]);
+  $schema->addIndex($table_name, $new_field_name, [$new_field_name], [
+    'fields' => [
+      $new_field_name => $spec,
+    ],
+  ]);
 }


### PR DESCRIPTION
Fixes creation of index in update hook.

Using `hoeringsportal_citizen_proposal_schema()` to get the table info may break if changes are made to what `hoeringsportal_citizen_proposal_schema` returns.
