### PR TITLE
FORSLAG-76: Removed email from citizen proposal support form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-333](https://github.com/itk-dev/hoeringsportal/pull/333)
+  Removed email from citizen proposal support form
+
 ## [3.1.0] - 2023-08-04 - Citizen proposal
 
 * [PR-331](https://github.com/itk-dev/hoeringsportal/pull/331)

--- a/web/modules/custom/hoeringsportal_citizen_proposal/src/Form/ProposalFormSupport.php
+++ b/web/modules/custom/hoeringsportal_citizen_proposal/src/Form/ProposalFormSupport.php
@@ -93,16 +93,6 @@ final class ProposalFormSupport extends ProposalFormBase {
       '#description_display' => 'before',
     ];
 
-    $form['email'] = [
-      '#type' => 'email',
-      '#required' => TRUE,
-      '#title' => $this
-        ->t('Email'),
-      '#default_value' => $defaltValues['email'],
-      '#description' => $this->getAdminFormStateValue('support_email_help'),
-      '#description_display' => 'before',
-    ];
-
     $form['actions']['#type'] = 'actions';
     $form['actions']['submit'] = [
       '#type' => 'submit',
@@ -121,7 +111,6 @@ final class ProposalFormSupport extends ProposalFormBase {
 
     return [
       'name' => $userData['name'] ?? NULL,
-      'email' => $userData['email'] ?? NULL,
     ];
   }
 
@@ -144,7 +133,6 @@ final class ProposalFormSupport extends ProposalFormBase {
         $node,
         [
           'user_name' => $form_state->getValue('name'),
-          'user_email' => $form_state->getValue('email'),
           'created' => time(),
         ],
       );


### PR DESCRIPTION
https://jira.itkdev.dk/browse/FORSLAG-76

Removes email from citizen proposal support form.

