### PR TITLE
FORSLAG-79: Hid “Author email display” from display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-335](https://github.com/itk-dev/hoeringsportal/pull/335)
+  Hid “Author email display” from display
+
 ## [3.1.0] - 2023-08-04 - Citizen proposal
 
 * [PR-331](https://github.com/itk-dev/hoeringsportal/pull/331)

--- a/config/sync/core.entity_view_display.node.citizen_proposal.default.yml
+++ b/config/sync/core.entity_view_display.node.citizen_proposal.default.yml
@@ -50,7 +50,6 @@ third_party_settings:
         - field_remarks
         - field_author_name
         - field_author_email
-        - field_author_email_display
       right:
         - field_vote_start
         - field_vote_end
@@ -83,16 +82,6 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 5
-    region: left
-  field_author_email_display:
-    type: boolean
-    label: hidden
-    settings:
-      format: default
-      format_custom_false: ''
-      format_custom_true: ''
-    third_party_settings: {  }
-    weight: 6
     region: left
   field_author_name:
     type: string
@@ -147,6 +136,7 @@ content:
     weight: 9
     region: right
 hidden:
+  field_author_email_display: true
   field_author_phone: true
   field_author_uuid: true
   field_content_state: true


### PR DESCRIPTION
https://jira.itkdev.dk/browse/FORSLAG-79

Hides field from display.
