### PR TITLE
FORSLAG-86: Added support redirect URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-345](https://github.com/itk-dev/hoeringsportal/pull/345)
+  Added support redirect URL
 * [PR-341](https://github.com/itk-dev/hoeringsportal/pull/341)
   Removed superfluous support proposal button
 * [PR-340](https://github.com/itk-dev/hoeringsportal/pull/340)

--- a/web/modules/custom/hoeringsportal_citizen_proposal/src/Form/ProposalAdminForm.php
+++ b/web/modules/custom/hoeringsportal_citizen_proposal/src/Form/ProposalAdminForm.php
@@ -174,13 +174,13 @@ final class ProposalAdminForm extends FormBase {
 
     $form['approve_form']['approve_goto_url'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Goto this url after submission'),
+      '#title' => $this->t('Redirect URL after a proposal has been submitted'),
       '#default_value' => $adminFormStateValues['approve_goto_url'] ?? '',
     ];
 
     $form['approve_form']['approve_submission_text'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Submission text when the proposal is approved.'),
+      '#title' => $this->t('Submission text when a proposal has been submitted'),
       '#default_value' => $adminFormStateValues['approve_submission_text'] ?? '',
     ];
 
@@ -210,9 +210,16 @@ final class ProposalAdminForm extends FormBase {
       '#default_value' => $adminFormStateValues['support_email_help'] ?? '',
     ];
 
+    $form['support_form']['support_goto_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Redirect URL after a proposal has been supported'),
+      '#default_value' => $adminFormStateValues['support_goto_url'] ?? '',
+      '#description' => $this->t('If not set, the citizen will see the proposal after supporting it.'),
+    ];
+
     $form['support_form']['support_submission_text'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Submission text when the proposal has been supported.'),
+      '#title' => $this->t('Submission text when a proposal has been supported'),
       '#default_value' => $adminFormStateValues['support_submission_text'] ?? '',
     ];
 

--- a/web/modules/custom/hoeringsportal_citizen_proposal/src/Form/ProposalFormBase.php
+++ b/web/modules/custom/hoeringsportal_citizen_proposal/src/Form/ProposalFormBase.php
@@ -150,12 +150,12 @@ abstract class ProposalFormBase extends FormBase {
   /**
    * Get admin form value as a URL.
    */
-  protected function getAdminFormStateValueUrl(string|array $key, string $default = NULL): Url {
+  protected function getAdminFormStateValueUrl(string|array $key, string $default = NULL, Url $defaultUrl = NULL): Url {
     try {
-      return Url::fromUserInput($this->helper->getAdminValue($key, $default));
+      return Url::fromUserInput($this->helper->getAdminValue($key, $default) ?? '');
     }
     catch (\Exception) {
-      return Url::fromRoute('<front>');
+      return $defaultUrl ?? Url::fromRoute('<front>');
     }
   }
 

--- a/web/modules/custom/hoeringsportal_citizen_proposal/src/Form/ProposalFormSupport.php
+++ b/web/modules/custom/hoeringsportal_citizen_proposal/src/Form/ProposalFormSupport.php
@@ -142,7 +142,9 @@ final class ProposalFormSupport extends ProposalFormBase {
     }
 
     $form_state->setRedirectUrl(
-      $this->deAuthenticateUser($node->toUrl())
+      $this->deAuthenticateUser(
+        $this->getAdminFormStateValueUrl('support_goto_url', NULL, $node->toUrl())
+      )
     );
   }
 


### PR DESCRIPTION
https://jira.itkdev.dk/browse/FORSLAG-86

Adds “Redirect URL after a proposal has been supported” to admin settings – and uses it to redirect a citizen after supporting a proposal.

