### PR TITLE
FORSLAG-74: Allowed citizen proposal editors to use Email HTML text format

### DIFF
--- a/config/sync/user.role.citizen_proposal_editor.yml
+++ b/config/sync/user.role.citizen_proposal_editor.yml
@@ -17,4 +17,5 @@ permissions:
   - 'administer citizen proposal'
   - 'edit any citizen_proposal content'
   - 'support citizen proposal on behalf of citizen'
+  - 'use text format email_html'
   - 'view the administration theme'


### PR DESCRIPTION
https://jira.itkdev.dk/browse/FORSLAG-74

Adds missing permission. Doesn't update the change log.

