### PR TITLE
FORSLAG-102: Cleaned up display of checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-360](https://github.com/itk-dev/hoeringsportal/pull/360)
+  Cleaned up display of checkboxes
 * [PR-359](https://github.com/itk-dev/hoeringsportal/pull/359)
   Generalized handling of form surveys. Added survey to support form
 * [PR-358](https://github.com/itk-dev/hoeringsportal/pull/358)

--- a/web/modules/custom/hoeringsportal_citizen_proposal/modules/hoeringsportal_citizen_proposal_fixtures/src/Fixture/CitizenProposalFixture/citizen_proposal_admin_form_values.yaml
+++ b/web/modules/custom/hoeringsportal_citizen_proposal/modules/hoeringsportal_citizen_proposal_fixtures/src/Fixture/CitizenProposalFixture/citizen_proposal_admin_form_values.yaml
@@ -13,6 +13,7 @@ citizen_proposal_admin_form_values:
   phone_help: 'Skriv dit telefonnummer. Dit telefonnummer kommer ikke til at fremgå offentligt.'
   email_help: 'Skriv din e-mail.'
   email_display_help: 'Ønsker du at vise din e-mail på hjemmesiden, så andre har mulighed for at kontakte dig?'
+  allow_email_help: 'Må vi sende en e-mail til dig?'
   proposal_intro:
     value: '<p>Her kan du skrive dit borgerforslag.&nbsp;</p>'
     format: filtered_html

--- a/web/modules/custom/hoeringsportal_citizen_proposal/src/Form/ProposalFormAdd.php
+++ b/web/modules/custom/hoeringsportal_citizen_proposal/src/Form/ProposalFormAdd.php
@@ -92,7 +92,6 @@ final class ProposalFormAdd extends ProposalFormBase {
         ->t('Display email'),
       '#default_value' => $defaltValues['email_display'] ?? TRUE,
       '#description' => $this->getAdminFormStateValue('email_display_help'),
-      '#description_display' => 'before',
     ];
 
     $form['allow_email'] = [

--- a/web/themes/custom/hoeringsportal/assets/css/module/_proposal.scss
+++ b/web/themes/custom/hoeringsportal/assets/css/module/_proposal.scss
@@ -3,6 +3,10 @@
     @extend .h5;
   }
 
+  .js-form-type-checkbox label {
+    margin-bottom: 0;
+  }
+
   .form-item--error-message {
     color: #863131;
 


### PR DESCRIPTION
https://jira.itkdev.dk/browse/FORSLAG-102

Makes display of checkboxes consistent.

Before:

<img width="773" alt="Screenshot 2023-08-29 at 11 18 13" src="https://github.com/itk-dev/hoeringsportal/assets/11267554/f31fb4ac-bd38-450b-974a-0190742330fa">

After:

<img width="773" alt="Screenshot 2023-08-29 at 11 18 32" src="https://github.com/itk-dev/hoeringsportal/assets/11267554/297a34cd-deac-488c-bb5b-667b671c2e8c">
