### PR TITLE
HRIN-767: Added GIS map token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-376](https://github.com/itk-dev/hoeringsportal/pull/376)
+  Added GIS map token
+
 ## [3.5.3] - 2023-11-08
 
 * [PR-370](https://github.com/itk-dev/hoeringsportal/pull/370)

--- a/composer.json
+++ b/composer.json
@@ -129,6 +129,7 @@
         "drupal/redirect": "^1.6",
         "drupal/search_autocomplete": "^2.0",
         "drupal/system_status": "^2.8",
+        "drupal/token_filter": "^2.1",
         "drupal/toolbar_visibility": "dev-3127402-drupal-9-readiness",
         "drupal/twig_tweak": "^2.1",
         "drupal/view_custom_table": "^2.0",
@@ -175,7 +176,8 @@
             "drupal/core-project-message": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "oomphinc/composer-installers-extender": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "chx/drupal-issue-fork": true
         }
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19e99cd5e4d2dc278c7fa1c7dcb7ddff",
+    "content-hash": "cb17acc6369296380767f182f363d3e6",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5445,6 +5445,75 @@
             "homepage": "https://www.drupal.org/project/token",
             "support": {
                 "source": "https://git.drupalcode.org/project/token"
+            }
+        },
+        {
+            "name": "drupal/token_filter",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/token_filter.git",
+                "reference": "2.1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/token_filter-2.1.0.zip",
+                "reference": "2.1.0",
+                "shasum": "34d72db7151738395afd25391195b36afb140bf1"
+            },
+            "require": {
+                "drupal/core": "^9.4 || ^10",
+                "drupal/token": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.1.0",
+                    "datestamp": "1698126115",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "ademarco",
+                    "homepage": "https://www.drupal.org/user/186696"
+                },
+                {
+                    "name": "asciikewl",
+                    "homepage": "https://www.drupal.org/user/147292"
+                },
+                {
+                    "name": "darvanen",
+                    "homepage": "https://www.drupal.org/user/1068770"
+                },
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                },
+                {
+                    "name": "Deciphered",
+                    "homepage": "https://www.drupal.org/user/103796"
+                },
+                {
+                    "name": "pescetti",
+                    "homepage": "https://www.drupal.org/user/436244"
+                },
+                {
+                    "name": "pvhee",
+                    "homepage": "https://www.drupal.org/user/108811"
+                }
+            ],
+            "description": "This is a very simple module to make global token values available as an input filter.",
+            "homepage": "https://www.drupal.org/project/token_filter",
+            "support": {
+                "source": "https://git.drupalcode.org/project/token_filter"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -98,6 +98,7 @@ module:
   telephone: 0
   text: 0
   token: 0
+  token_filter: 0
   toolbar: 0
   toolbar_visibility: 0
   twig_tweak: 0

--- a/config/sync/editor.editor.hearing_description.yml
+++ b/config/sync/editor.editor.hearing_description.yml
@@ -1,0 +1,59 @@
+uuid: d4a16c11-faf2-4617-bd62-c28ad4eb5f31
+langcode: da
+status: true
+dependencies:
+  config:
+    - filter.format.hearing_description
+  module:
+    - ckeditor5
+format: hearing_description
+editor: ckeditor5
+settings:
+  toolbar:
+    items:
+      - bold
+      - italic
+      - '|'
+      - link
+      - '|'
+      - bulletedList
+      - numberedList
+      - '|'
+      - blockQuote
+      - '|'
+      - sourceEditing
+      - '|'
+      - heading
+      - tokenBrowser
+  plugins:
+    ckeditor5_heading:
+      enabled_headings:
+        - heading2
+        - heading3
+        - heading4
+    ckeditor5_list:
+      reversed: false
+      startIndex: true
+    ckeditor5_sourceEditing:
+      allowed_tags:
+        - '<cite>'
+        - '<a hreflang target>'
+        - '<blockquote cite>'
+        - '<ul type>'
+        - '<ol type>'
+        - '<h2 id>'
+        - '<h3 id>'
+        - '<h4 id>'
+    editor_advanced_link_link:
+      enabled_attributes:
+        - target
+    token_filter_token_browser:
+      token_types: {  }
+image_upload:
+  status: false
+  scheme: public
+  directory: inline-images
+  max_size: ''
+  max_dimensions:
+    width: null
+    height: null

--- a/config/sync/field.field.node.hearing.field_description.yml
+++ b/config/sync/field.field.node.hearing.field_description.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_description
+    - filter.format.hearing_description
     - node.type.hearing
   module:
     - allowed_formats
@@ -11,7 +12,7 @@ dependencies:
 third_party_settings:
   allowed_formats:
     allowed_formats:
-      - filtered_html
+      - hearing_description
 id: node.hearing.field_description
 field_name: field_description
 entity_type: node
@@ -22,5 +23,7 @@ required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats:
+    - hearing_description
 field_type: text_long

--- a/config/sync/filter.format.hearing_description.yml
+++ b/config/sync/filter.format.hearing_description.yml
@@ -1,0 +1,45 @@
+uuid: 15881684-2eac-4426-bae4-7e44d395c82a
+langcode: da
+status: true
+dependencies:
+  module:
+    - token_filter
+name: 'Hearing description'
+format: hearing_description
+weight: 0
+filters:
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: 9
+    settings: {  }
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: -50
+    settings: {  }
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: false
+    weight: -50
+    settings:
+      filter_url_length: 72
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: 0
+    settings:
+      allowed_html: '<br> <p> <h2 id> <h3 id> <h4 id> <cite> <a hreflang target href> <blockquote cite> <ul type> <ol type start> <strong> <em> <li>'
+      filter_html_help: true
+      filter_html_nofollow: false
+  token_filter:
+    id: token_filter
+    provider: token_filter
+    status: true
+    weight: 15
+    settings:
+      replace_empty: '1'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - filter.format.citizen_proposal_content
     - filter.format.filtered_html
+    - filter.format.hearing_description
   module:
     - filter
     - media
@@ -21,4 +22,5 @@ permissions:
   - 'search content'
   - 'use text format citizen_proposal_content'
   - 'use text format filtered_html'
+  - 'use text format hearing_description'
   - 'view media'

--- a/web/modules/custom/hoeringsportal_data/src/Plugin/Field/FieldWidget/MapDefaultWidget.php
+++ b/web/modules/custom/hoeringsportal_data/src/Plugin/Field/FieldWidget/MapDefaultWidget.php
@@ -65,7 +65,7 @@ class MapDefaultWidget extends WidgetBase {
     $geojsonUrl = 'http://geojson.io/';
     $geojsonUrlWithMap = $geojsonUrl . '#map=13/56.1464/10.1739';
     // @see https://github.com/mapbox/geojson.io/blob/gh-pages/API.md#datadataapplicationjson
-    $geojsonUrlWithData = $geojsonUrl . '#data=data:application/json,' . urlencode(json_encode(json_decode($item->geojson)) ?? '');
+    $geojsonUrlWithData = $geojsonUrl . '#data=data:application/json,' . urlencode(json_encode(json_decode($item->geojson ?? 'null')) ?? '');
     $element['geojson'] = [
       '#type' => 'textarea',
       '#title' => t('GeoJSON'),

--- a/web/modules/custom/hoeringsportal_hearing/assets/css/gis-minimap.css
+++ b/web/modules/custom/hoeringsportal_hearing/assets/css/gis-minimap.css
@@ -1,0 +1,11 @@
+.hoeringsportal-hearing-gis-minimap {
+  /* We use a `span` element to render the map (it's most times inside a `p` element). */
+  display: block;
+  height: 500px;
+}
+
+.hoeringsportal-hearing-gis-minimap.invalid-token {
+  color: #f00;
+  background: #ff0;
+  height: auto;
+}

--- a/web/modules/custom/hoeringsportal_hearing/hoeringsportal_hearing.install
+++ b/web/modules/custom/hoeringsportal_hearing/hoeringsportal_hearing.install
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Code related to installing and updating this module.
+ */
+
+/**
+ * Update text format on hearing description.
+ */
+function hoeringsportal_hearing_update_9001() {
+  $storage = \Drupal::entityTypeManager()
+    ->getStorage('node');
+  $ids = $storage->getQuery()
+    ->condition('type', 'hearing')
+    ->accessCheck(FALSE)
+    ->execute();
+  $hearings = $storage->loadMultiple($ids);
+
+  $field_name = 'field_description';
+  $text_format = 'hearing_description';
+  foreach ($hearings as $hearing) {
+    if ($value = ($hearing->get($field_name)->getValue()[0] ?? NULL)) {
+      $value['format'] = $text_format;
+      $hearing->set($field_name, $value);
+
+      $hearing->save();
+    }
+  }
+}

--- a/web/modules/custom/hoeringsportal_hearing/hoeringsportal_hearing.libraries.yml
+++ b/web/modules/custom/hoeringsportal_hearing/hoeringsportal_hearing.libraries.yml
@@ -2,3 +2,11 @@ hearing-form:
   version: VERSION
   js:
     assets/js/form.js: {}
+
+gis-minimap:
+  version: VERSION
+  css:
+    theme:
+      assets/css/gis-minimap.css: {}
+  js:
+    https://webkort.aarhuskommune.dk/clientapi/minimap2/mmloader.js: { type: external, minified: true }

--- a/web/modules/custom/hoeringsportal_hearing/hoeringsportal_hearing.module
+++ b/web/modules/custom/hoeringsportal_hearing/hoeringsportal_hearing.module
@@ -9,8 +9,10 @@ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
+use Drupal\hoeringsportal_hearing\TokenHelper;
 
 /**
  * Implements hook_help().
@@ -82,6 +84,23 @@ function hoeringsportal_hearing_node_view(array &$build, EntityInterface $entity
       $new_title = $title . $state;
       $build['title'][0]['#context']['value'] = $new_title;
     }
-
   }
+}
+
+/**
+ * Implements hook_token_info().
+ *
+ * @see \Drupal\hoeringsportal_hearing\TokenHelper::tokenInfo()
+ */
+function hoeringsportal_hearing_token_info() {
+  return \Drupal::service(TokenHelper::class)->tokenInfo();
+}
+
+/**
+ * Implements hook_tokens().
+ *
+ * @see \Drupal\hoeringsportal_hearing\TokenHelper::tokens()
+ */
+function hoeringsportal_hearing_tokens($type, $tokens, array $data, array $options, BubbleableMetadata $bubbleable_metadata) {
+  return \Drupal::service(TokenHelper::class)->tokens($type, $tokens, $data, $options, $bubbleable_metadata);
 }

--- a/web/modules/custom/hoeringsportal_hearing/hoeringsportal_hearing.services.yml
+++ b/web/modules/custom/hoeringsportal_hearing/hoeringsportal_hearing.services.yml
@@ -3,3 +3,5 @@ services:
     class: Drupal\hoeringsportal_hearing\EventSubscriber\EventSubscriber
     tags:
       - {name: event_subscriber}
+
+  Drupal\hoeringsportal_hearing\TokenHelper:

--- a/web/modules/custom/hoeringsportal_hearing/modules/hoeringsportal_hearing_fixtures/src/Fixture/HearingFixture.php
+++ b/web/modules/custom/hoeringsportal_hearing/modules/hoeringsportal_hearing_fixtures/src/Fixture/HearingFixture.php
@@ -30,7 +30,7 @@ class HearingFixture extends AbstractFixture implements DependentFixtureInterfac
 Lorem ipsum bum bum bum.
 
 Dette er en høring. Den har ID node:landing_page:Hearing1 ',
-        'format' => 'filtered_html',
+        'format' => 'hearing_description',
       ],
       'field_media_image' => [
         ['target_id' => $this->getReference('media:Medium1')->id()],
@@ -46,7 +46,7 @@ Dette er en høring. Den har ID node:landing_page:Hearing1 ',
       'field_reply_deadline' => DrupalDateTime::createFromFormat('U', strtotime('tomorrow'))->format('Y-m-d\TH:i:s'),
       'field_edoc_casefile_id' => '',
       'field_tags' => ['target_id' => $this->getReference('tags:Kultur og borgerservice')->id()],
-      'field_getorganized_case_id' => '',
+      'field_getorganized_case_id' => 'test-case-id',
       'field_contact'  => [
         'value' => '
 This is the contact field.
@@ -54,15 +54,23 @@ This is the contact field.
 Input address here.',
         'format' => 'filtered_html',
       ],
-      'field_map' => '',
+      'field_map' => [
+        'type' => 'point',
+        'data' => '{"type":"Feature","properties":[],"geometry":{"type":"Point","coordinates":[10.213748135074276,56.15345564612786]}}',
+        'geojson' => '',
+        'localplanids' => '',
+        'point' => '{"type":"FeatureCollection","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"features":[{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[10.213748135074276,56.15345564612786]}}]}',
+      ],
       'field_map_display' => '',
       'field_lokalplaner' => '',
       'field_area' => ['target_id' => $this->getReference('area:Hele kommunen')->id()],
       'field_project_reference' => '',
-      'field_deskpro_agent_email' => '',
+      // If we're lucky this Deskpro data makes sense.
+      'field_deskpro_department_id' => 12,
+      'field_deskpro_agent_email' => 'deskpro@example.com',
       'field_teaser' => 'Lorem ipsum teaser',
       'field_hearing_ticket_add' => '',
-      'field_type' => ['target_id' => $this->getReference('hearing_type:Kommuneplan:Temaplan detailhandel')->id()],
+      'field_type' => ['target_id' => $this->getReference('type:Kommuneplan')->id()],
       'field_video_embed' => '',
       'field_more_info' => [
         'value' => '
@@ -75,6 +83,26 @@ Lorem ipsum 1234 Lorem ipsum',
     ]);
     $entity->save();
     $this->addReference('node:hearing:Hearing1', $entity);
+
+    $entity = $entity->createDuplicate();
+    $entity->setTitle('Høring med GIS-kort');
+    $entity->set('field_description', [
+      'value' => <<<'EOD'
+<h2>Et GIS-kort</h2>
+
+<p>[gis:minimap:409c1dc9-b604-4f1e-9df9-2768d050acb4]</p>
+
+
+<h2>Et lavt GIS-kort</h2>
+<p>[gis:minimap:409c1dc9-b604-4f1e-9df9-2768d050acb4:height=200px]</p>
+
+<h2>Et ugyldigt kort</h2>
+
+<p>[gis:minimap:hest]</p>
+EOD,
+      'format' => 'hearing_description',
+    ]);
+    $entity->save();
   }
 
   /**

--- a/web/modules/custom/hoeringsportal_hearing/src/TokenHelper.php
+++ b/web/modules/custom/hoeringsportal_hearing/src/TokenHelper.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Drupal\hoeringsportal_hearing;
+
+use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Component\Uuid\Uuid;
+use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Template\Attribute;
+
+/**
+ * Token helper.
+ */
+final class TokenHelper {
+  use StringTranslationTrait;
+
+  /**
+   * Token info.
+   *
+   * @implements hook_token_info().
+   */
+  public function tokenInfo(): array {
+    return [
+      'types' => [
+        'gis' => [
+          'name' => $this->t('GIS data'),
+        ],
+      ],
+      'tokens' => [
+        'gis' => [
+          'minimap:?' => [
+            'name' => $this->t('Insert GIS minimap by UUID'),
+            'description' => $this->t('Example: <code>[gis:minimap:409c1dc9-b604-4f1e-9df9-2768d050acb4]</code>'),
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Tokens.
+   *
+   * @implements hook_tokens().
+   */
+  public function tokens($type, $tokens, array $data, array $options, BubbleableMetadata $bubbleableMetadata): array {
+    $replacements = [];
+    if ('gis' === $type) {
+      foreach ($tokens as $name => $original) {
+        if (preg_match('/^minimap:(?P<uuid>[^:]+)(?:\:(?P<config>.+))?$/', $name, $matches)) {
+          $mapUuid = $matches['uuid'];
+          $elementAttributes = new Attribute();
+          $elementAttributes->addClass('hoeringsportal-hearing-gis-minimap');
+          if (Uuid::isValid($mapUuid)) {
+            $elementId = uniqid('gis-minimap-');
+            parse_str($matches['config'] ?? '', $config);
+            $elementStyle['height'] = $config['height'] ?? '500px';
+            $script = sprintf('<script>window.addEventListener("load", function() { MiniMap.createMiniMap({mapDiv: "%s", minimapId: "%s"}) })</script>',
+              $elementId, $mapUuid);
+
+            $elementAttributes->setAttribute('id', $elementId);
+            // Build CSS style from associative array with, e.g.
+            // ['height' => '500px', 'width' => '50%']
+            // -> 'height: 500px; width: 50%'.
+            $style = implode(
+              '; ',
+              // Convert array to list of `«property»: «value»`.
+              array_map(
+                static fn($property, $value) => $property . ': ' . $value, array_keys($elementStyle),
+                $elementStyle
+              )
+            );
+            $elementAttributes->setAttribute('style', $style);
+            // Note: We use a `span` element (rather than a `div` element) for
+            // the map since we're (most times) inside a `p` element.
+            $markup = sprintf('<span %s></span>', $elementAttributes);
+
+            $replacements[$original] = new FormattableMarkup($script . $markup,
+              []);
+          }
+          else {
+            $elementAttributes->addClass('invalid-token');
+            $elementAttributes->setAttribute('title', $this->t('Invalid GIS map UUID: @map_uuid', ['@map_uuid' => $mapUuid]));
+            $replacements[$original] = new FormattableMarkup(
+              sprintf('<span %s>%s</span>', $elementAttributes, $original),
+              []
+            );
+          }
+        }
+        $bubbleableMetadata->addAttachments(['library' => ['hoeringsportal_hearing/gis-minimap']]);
+      }
+    }
+
+    return $replacements;
+  }
+
+}


### PR DESCRIPTION
https://jira.itkdev.dk/browse/HRIN-767

Adds GIS map token for use in hearing descriptions.

### Editor view
<img width="1127" alt="Screenshot 2023-12-19 at 13 44 47" src="https://github.com/itk-dev/hoeringsportal/assets/11267554/c0b984bf-3d0a-496f-a060-7a93a5168d6f">

### Frontend display

<img width="736" alt="Screenshot 2023-12-18 at 13 39 19" src="https://github.com/itk-dev/hoeringsportal/assets/11267554/2e782ab5-261b-4d3d-a679-47ea27130bdf">

### Important note on updating

We have an issue with “plandata” that is used somewhere:

<https://geoserver.plandata.dk/geoserver/wfs?request=GetFeature&typeNames=pdk%3Alokalplan&srsName=EPSG%3A4326&outputFormat=application%2Fjson&cql_filter=planid%20IN%20%289417152%29&servicename=wfs&service=wfs&version=2.0.0>:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<ows:ExceptionReport xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.0" xsi:schemaLocation="http://www.opengis.net/ows/1.1 https://geoserver.plandata.dk/geoserver/schemas/ows/1.1.0/owsAll.xsd">
 <ows:Exception exceptionCode="InvalidParameterValue" locator="typeName">
  <ows:ExceptionText>Feature type pdk:lokalplan unknown</ows:ExceptionText>
 </ows:Exception>
</ows:ExceptionReport>
```

which makes `hoeringsportal_hearing_update_9001` fail.

Therefore, we manually apply the text format update and skip the update hook:

```shell
# Update hearing description text format.
docker compose exec phpfpm vendor/bin/drush sql:query "UPDATE node__field_description SET field_description_format = 'hearing_description' WHERE bundle = 'hearing';"
# Skip the update hook.
docker compose exec phpfpm vendor/bin/drush php:eval "\Drupal::service('update.update_hook_registry')->setInstalledVersion('hoeringsportal_hearing', 9001);"
# Run the real update.
docker compose exec phpfpm vendor/bin/drush --yes deploy
```
