### PR TITLE
1152: Fixed rendering of headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-392](https://github.com/itk-dev/hoeringsportal/pull/392)
+  1152: Fixed rendering of headers
+
 ## [4.2.1] - 2024-04-04
 
 * [pr-390](https://github.com/itk-dev/hoeringsportal/pull/390)

--- a/web/themes/custom/hoeringsportal/templates/components/header.html.twig
+++ b/web/themes/custom/hoeringsportal/templates/components/header.html.twig
@@ -4,7 +4,13 @@
 <div class="container">
   <div class="row">
     <div class="col-md-8 my-3 my-md-5">
-      <h1 class="title underlined is-white hero__title">{{ header|without('dynamic_block_field:node-hearing_warning') }}</h1>
+      <h1 class="title underlined is-white hero__title">
+        {% if header['dynamic_block_field:node-hearing_warning'] is defined %}
+          {{ header|without('dynamic_block_field:node-hearing_warning') }}
+        {% else %}
+          {{ header }}
+        {% endif %}
+      </h1>
       {% if teaser %}
         {{ teaser }}
       {% endif %}


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/1152

Fixes issue with the `without` filter being used on non-array values.


