### PR TITLE
1983: Removed .placeholder markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-413](https://github.com/itk-dev/hoeringsportal/pull/413)
+  Removed `.placeholder` markup
 * [PR-411](https://github.com/itk-dev/hoeringsportal/pull/411)
   Fix paragraph spacing
 * [PR-409](https://github.com/itk-dev/hoeringsportal/pull/409)

--- a/web/modules/custom/hoeringsportal_citizen_proposal/src/Form/ProposalFormBase.php
+++ b/web/modules/custom/hoeringsportal_citizen_proposal/src/Form/ProposalFormBase.php
@@ -89,7 +89,7 @@ abstract class ProposalFormBase extends FormBase {
         '#attributes' => ['class' => ['authenticate-wrapper', 'py-3']],
 
         'message' => [
-          '#markup' => $this->t("You're currently authenticated as %name", ['%name' => $userData['name']]),
+          '#markup' => $this->t("You're currently authenticated as @name", ['@name' => $userData['name']]),
         ],
 
         'link' => Link::createFromRoute(


### PR DESCRIPTION
https://leantime.itkdev.dk/dashboard/home#/tickets/showTicket/1983

Drupal adds a `placeholder` class on text marked up with `%placeholder` (using [`t`](https://api.drupal.org/api/drupal/core%21includes%21bootstrap.inc/function/t/11.x)), but the `placeholder` class is styled by Bootstrap (https://getbootstrap.com/docs/5.3/components/placeholders/#how-it-works) in a way that we do not want.

Before:

![deltag aarhus dk_citizen_proposal_add](https://github.com/user-attachments/assets/7b696f70-88dc-454d-b23c-0af71ac984fe)

After:

![deltag aarhus dk_citizen_proposal_add (1)](https://github.com/user-attachments/assets/9848edd1-006c-41aa-a6d9-7fb46235688f)
