### PR TITLE
Increase nginx max body size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-416](https://github.com/itk-dev/hoeringsportal/pull/416)
+  Increase nginx max body size
+
 ## [4.5.0] - 2024-08-19
 
 * [PR-412](https://github.com/itk-dev/hoeringsportal/pull/412)

--- a/docker-compose.server.override.yml
+++ b/docker-compose.server.override.yml
@@ -7,6 +7,11 @@ services:
       - PHP_OPCACHE_VALIDATE_TIMESTAMPS=0
       - PHP_MEMORY_LIMIT=528M
 
+  nginx:
+    environment:
+      # Match PHP_UPLOAD_MAX_FILESIZE (plus a little more)
+      NGINX_MAX_BODY_SIZE: 90M
+
   node:
     image: node:18
     volumes:


### PR DESCRIPTION
https://leantime.itkdev.dk/dashboard/home#/tickets/showTicket/2293

Our configuration of nginx's [`client_max_body_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) does not match PHP's [`upload_max_filesize`](https://www.php.net/manual/en/ini.core.php#ini.upload-max-filesize) and therefore huge images (with a size over 5 MB) cannot be uploaded.
