### PR TITLE
2288: Deleted hearing replies after delete_date is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-419](https://github.com/itk-dev/hoeringsportal/pull/419)
+  Added Drush command to delete hearing replies
 * [PR-418](https://github.com/itk-dev/hoeringsportal/pull/418)
-  Add message when hearing tickets is deleted.
+  Add message when hearing replies are deleted
 * [PR-417](https://github.com/itk-dev/hoeringsportal/pull/417)
   Added more test setup stuff
 

--- a/config/sync/field.field.node.hearing.field_delete_date.yml
+++ b/config/sync/field.field.node.hearing.field_delete_date.yml
@@ -11,8 +11,8 @@ id: node.hearing.field_delete_date
 field_name: field_delete_date
 entity_type: node
 bundle: hearing
-label: 'Slette dato'
-description: 'Bruges til at sætte dato for sletning af høringssvar.'
+label: 'Dato for sletning af høringssvar'
+description: 'Vælg hvornår høringssvar skal slettes fra høringen.'
 required: true
 translatable: false
 default_value: {  }

--- a/documentation/localDevelopment.md
+++ b/documentation/localDevelopment.md
@@ -78,7 +78,7 @@ docker compose exec phpfpm vendor/bin/drush --yes --uri="http://hoeringsportal.l
 
 Add all fixtures
 
-```sh
+```sh name=load-fixtures
 docker compose exec phpfpm vendor/bin/drush --yes pm:enable hoeringsportal_base_fixtures $(find web/modules/custom -type f -name 'hoeringsportal_*_fixtures.info.yml' -exec basename -s .info.yml {} \;)
 docker compose exec phpfpm vendor/bin/drush --yes content-fixtures:load
 docker compose exec phpfpm vendor/bin/drush --yes pm:uninstall content_fixtures

--- a/web/modules/custom/hoeringsportal_data/README.md
+++ b/web/modules/custom/hoeringsportal_data/README.md
@@ -36,6 +36,19 @@ e.g. every minute
 */5 * * * * drush hoeringsportal:data:hearing-state-update
 ```
 
+Delete replies on hearings by running
+
+```sh
+drush hoeringsportal:data:delete-replies
+```
+
+This should be done regularly by `cron` or other similar means,
+e.g. daily at 03:00
+
+```sh
+0 3 * * * drush hoeringsportal:data:delete-replies
+```
+
 ## Building assets
 
 First, install tools and requirements:

--- a/web/modules/custom/hoeringsportal_data/hoeringsportal_data.services.yml
+++ b/web/modules/custom/hoeringsportal_data/hoeringsportal_data.services.yml
@@ -1,4 +1,8 @@
 services:
+  logger.channel.hoeringsportal_data:
+    parent: logger.channel_base
+    arguments: [ 'hoeringsportal_data' ]
+
   hoeringsportal_data.plandata:
     class: Drupal\hoeringsportal_data\Service\Plandata
     arguments: ['@settings']
@@ -8,7 +12,7 @@ services:
 
   hoeringsportal_data.hearing_helper:
     class: Drupal\hoeringsportal_data\Helper\HearingHelper
-    arguments: ['@entity_type.manager']
+    arguments: ['@entity_type.manager', '@logger.channel.hoeringsportal_data']
 
   hoeringsportal_data.map_item_helper:
     class: Drupal\hoeringsportal_data\Helper\MapItemHelper

--- a/web/modules/custom/hoeringsportal_data/src/Drush/Commands/DrushCommands.php
+++ b/web/modules/custom/hoeringsportal_data/src/Drush/Commands/DrushCommands.php
@@ -2,7 +2,11 @@
 
 namespace Drupal\hoeringsportal_data\Drush\Commands;
 
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\State\StateInterface;
 use Drupal\hoeringsportal_data\Helper\HearingHelper;
+use Drupal\hoeringsportal_deskpro\Service\HearingHelper as DeskproHearingHelper;
 use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands as BaseDrushCommands;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -17,6 +21,9 @@ final class DrushCommands extends BaseDrushCommands {
    */
   public function __construct(
     private readonly HearingHelper $helper,
+    private readonly DeskproHearingHelper $deskproHelper,
+    private readonly TimeInterface $time,
+    private readonly StateInterface $state,
   ) {
     parent::__construct();
   }
@@ -27,6 +34,9 @@ final class DrushCommands extends BaseDrushCommands {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('hoeringsportal_data.hearing_helper'),
+      $container->get('hoeringsportal_deskpro.helper'),
+      $container->get('datetime.time'),
+      $container->get('state')
     );
   }
 
@@ -64,6 +74,67 @@ final class DrushCommands extends BaseDrushCommands {
     foreach ($hearings as $hearing) {
       $this->writeln(sprintf('%4d: %s', $hearing->id(), $this->helper->getState($hearing)));
     }
+  }
+
+  /**
+   * A drush command for deleting replies from hearings.
+   */
+  #[CLI\Command(name: 'hoeringsportal:data:delete-replies')]
+  public function processDeleteHearingReplies(
+    array $options = [
+      'last-run-at' => NULL,
+    ],
+  ): void {
+    $lastRunAt = $options['last-run-at'] ? new DrupalDateTime($options['last-run-at']) : $this->getLastRunAt(__METHOD__);
+    $requestTime = $this->getRequestTime();
+
+    $hearingIds = $this->helper->findHearingWhoseRepliesMustBeDeleted($lastRunAt,
+      $requestTime);
+
+    if ($this->io()->isVerbose()) {
+      $this->io()->info(sprintf('Deleting hearing replies between %s and %s: %s', $lastRunAt->format('Y-m-d'), $requestTime->format('Y-m-d'), implode(', ', $hearingIds)));
+    }
+
+    if ($options['yes'] || $this->confirm(sprintf('Delete replies on hearings %s', implode(', ', $hearingIds)))) {
+      $result = $this->deskproHelper->deleteHearingReplies($hearingIds);
+
+      $this->io()->success(1 === $result
+        ? sprintf('Replies deleted from 1 hearing: %s', implode(', ', $hearingIds))
+        : sprintf('Replies deleted from %d hearings: %s', $result, implode(', ', $hearingIds))
+      );
+
+      $this->setLastRunAt(__METHOD__);
+    }
+  }
+
+  /**
+   * Get request time.
+   */
+  private function getRequestTime(): DrupalDateTime {
+    return DrupalDateTime::createFromTimestamp($this->time->getRequestTime());
+  }
+
+  /**
+   * Get time of last run.
+   */
+  private function getLastRunAt(string $method): DrupalDateTime {
+    $time = $this->state->get($this->getLastRunKey($method));
+
+    return DrupalDateTime::createFromTimestamp($time ?? 0);
+  }
+
+  /**
+   * Set time of last run.
+   */
+  private function setLastRunAt(string $method) {
+    $this->state->set($this->getLastRunKey($method), $this->time->getRequestTime());
+  }
+
+  /**
+   * Get last run key.
+   */
+  private function getLastRunKey(string $method): string {
+    return $method . '_last_run_at';
   }
 
 }

--- a/web/modules/custom/hoeringsportal_data/src/Helper/HearingHelper.php
+++ b/web/modules/custom/hoeringsportal_data/src/Helper/HearingHelper.php
@@ -93,23 +93,6 @@ class HearingHelper implements LoggerAwareInterface {
   }
 
   /**
-   * Check if hearing's delete replies date is passed.
-   */
-  public function isDeleteRepliesDatePassed(NodeInterface $node) {
-    if (!$this->isHearing($node)) {
-      return FALSE;
-    }
-
-    $deadline = $node->field_delete_date->date;
-
-    if (empty($deadline)) {
-      return FALSE;
-    }
-
-    return $this->getDateTime() > new DrupalDateTime($deadline);
-  }
-
-  /**
    * Find hearings whose replies must be deleted.
    *
    * @return array

--- a/web/modules/custom/hoeringsportal_deskpro/hoeringsportal_deskpro.install
+++ b/web/modules/custom/hoeringsportal_deskpro/hoeringsportal_deskpro.install
@@ -13,44 +13,6 @@ use Drupal\node\Entity\Node;
  */
 function hoeringsportal_deskpro_schema() {
   return [
-    'hoeringsportal_deskpro_deskpro_data' => [
-      'description' => 'Table to hold information about Deskpro data for nodes.',
-      'fields' => [
-        'entity_type' => [
-          'description' => 'The entity type',
-          'type' => 'varchar',
-          'length' => 128,
-          'not null' => TRUE,
-          'default' => '',
-        ],
-        'entity_id' => [
-          'description' => 'The entity id',
-          'type' => 'int',
-          'unsigned' => TRUE,
-          'not null' => TRUE,
-        ],
-        'bundle' => [
-          'description' => 'The entity bundle',
-          'type' => 'varchar',
-          'length' => 128,
-          'not null' => TRUE,
-          'default' => '',
-        ],
-        'data' => [
-          'description' => 'Deskpro data (JSON)',
-          'type' => 'text',
-          'size' => 'big',
-          'not null' => TRUE,
-          'default' => '{}',
-        ],
-      ],
-      'primary key' => [
-        'entity_type',
-        'entity_id',
-        'bundle',
-      ],
-    ],
-
     'hoeringsportal_deskpro_deskpro_tickets' => [
       'description' => 'Table to hold information about Deskpro tickets for nodes.',
       'fields' => [
@@ -390,4 +352,14 @@ function hoeringsportal_deskpro_update_8004(&$sandbox) {
     // to the user.
     return t('Batch finished');
   }
+}
+
+/**
+ * Drop hoeringsportal_deskpro_deskpro_data table.
+ */
+function hoeringsportal_deskpro_update_8005(&$sandbox) {
+  /** @var \Drupal\Core\Database\Connection $connection */
+  $connection = \Drupal::service('database');
+  $schema = $connection->schema();
+  $schema->dropTable('hoeringsportal_deskpro_deskpro_data');
 }

--- a/web/modules/custom/hoeringsportal_deskpro/hoeringsportal_deskpro.module
+++ b/web/modules/custom/hoeringsportal_deskpro/hoeringsportal_deskpro.module
@@ -37,7 +37,7 @@ function hoeringsportal_deskpro_theme() {
         'is_deadline_passed' => NULL,
         'tickets' => NULL,
         'is_hearing_started' => NULL,
-        'is_delete_replies_date_passed' => NULL,
+        'hearing_replies_deleted_on' => NULL,
       ],
     ],
     'hoeringsportal_hearing_ticket' => [

--- a/web/modules/custom/hoeringsportal_deskpro/hoeringsportal_deskpro.module
+++ b/web/modules/custom/hoeringsportal_deskpro/hoeringsportal_deskpro.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_help().
@@ -111,4 +112,15 @@ function hoeringsportal_deskpro_entity_bundle_field_info_alter(&$fields, EntityT
   if ('hearing' === $bundle && isset($fields['field_deskpro_agent_email'])) {
     $fields['field_deskpro_agent_email']->addConstraint('AgentEmail');
   }
+}
+
+/**
+ * Implements hook_node_update().
+ *
+ * @see \Drupal\hoeringsportal_data\Helper\HearingHelper::nodeUpdate();
+ */
+function hoeringsportal_deskpro_node_update(NodeInterface $node) {
+  /** @var \Drupal\hoeringsportal_deskpro\Service\HearingHelper $helper */
+  $helper = \Drupal::service('hoeringsportal_deskpro.helper');
+  $helper->nodeUpdate($node);
 }

--- a/web/modules/custom/hoeringsportal_deskpro/hoeringsportal_deskpro.module
+++ b/web/modules/custom/hoeringsportal_deskpro/hoeringsportal_deskpro.module
@@ -37,6 +37,7 @@ function hoeringsportal_deskpro_theme() {
         'is_deadline_passed' => NULL,
         'tickets' => NULL,
         'is_hearing_started' => NULL,
+        'is_delete_replies_date_passed' => NULL,
       ],
     ],
     'hoeringsportal_hearing_ticket' => [

--- a/web/modules/custom/hoeringsportal_deskpro/src/Plugin/Block/HearingTicketsBlock.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/Plugin/Block/HearingTicketsBlock.php
@@ -35,6 +35,7 @@ class HearingTicketsBlock extends BlockBase {
       '#is_deadline_passed' => $this->helper->isDeadlinePassed($node),
       '#tickets' => $this->helper->getHearingTickets($node),
       '#is_hearing_started' => $is_hearing_started,
+      '#is_delete_replies_date_passed' => $this->helper->isDeleteRepliesDatePassed($node),
     ];
   }
 

--- a/web/modules/custom/hoeringsportal_deskpro/src/Plugin/Block/HearingTicketsBlock.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/Plugin/Block/HearingTicketsBlock.php
@@ -35,7 +35,7 @@ class HearingTicketsBlock extends BlockBase {
       '#is_deadline_passed' => $this->helper->isDeadlinePassed($node),
       '#tickets' => $this->helper->getHearingTickets($node),
       '#is_hearing_started' => $is_hearing_started,
-      '#is_delete_replies_date_passed' => $this->helper->isDeleteRepliesDatePassed($node),
+      '#hearing_replies_deleted_on' => $this->helper->getHearingRepliesDeletedOn($node),
     ];
   }
 

--- a/web/modules/custom/hoeringsportal_deskpro/src/Service/HearingHelper.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/Service/HearingHelper.php
@@ -81,6 +81,10 @@ class HearingHelper {
    * Check if hearing deadline is passed.
    */
   public function isDeadlinePassed(NodeInterface $node) {
+    if ($this->isDeleteRepliesDatePassed($node)) {
+      return TRUE;
+    }
+
     if (!$this->isHearing($node)) {
       return FALSE;
     }
@@ -93,6 +97,23 @@ class HearingHelper {
 
     // Allow users with edit access to do stuff after the deadline.
     if ($node->access('edit', \Drupal::currentUser())) {
+      return FALSE;
+    }
+
+    return new DrupalDateTime() > new DrupalDateTime($deadline);
+  }
+
+  /**
+   * Check if hearing's delete replies date is passed.
+   */
+  public function isDeleteRepliesDatePassed(NodeInterface $node): bool {
+    if (!$this->isHearing($node)) {
+      return FALSE;
+    }
+
+    $deadline = $node->field_delete_date->date;
+
+    if (empty($deadline)) {
       return FALSE;
     }
 
@@ -625,6 +646,21 @@ class HearingHelper {
     }
 
     return $info[$bundle][$entity_id][$ticketId] ?? NULL;
+  }
+
+  /**
+   * Delete hearing replies.
+   */
+  public function deleteHearingReplies(array $nodeIds): int {
+    if (empty($nodeIds)) {
+      return 0;
+    }
+
+    return $this->database->delete('hoeringsportal_deskpro_deskpro_tickets')
+      ->condition('entity_type', 'node', '=')
+      ->condition('bundle', 'hearing')
+      ->condition('entity_id', $nodeIds, 'IN')
+      ->execute();
   }
 
   /**

--- a/web/modules/custom/hoeringsportal_deskpro/src/Service/HearingHelper.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/Service/HearingHelper.php
@@ -665,6 +665,32 @@ class HearingHelper {
   }
 
   /**
+   * Implements hook_node_update().
+   */
+  public function nodeUpdate(NodeInterface $node) {
+    if ($this->isHearing($node)) {
+      $date = $this->getHearingRepliesDeletedOn($node);
+      if (NULL !== $date) {
+        try {
+          $result = $this->deleteHearingReplies([$node->id()]);
+          $this->logger->info('Deleted hearing replies from hearing @label (@id): @result', [
+            '@id' => $node->id(),
+            '@label' => $node->label(),
+            '@result' => $result,
+          ]);
+        }
+        catch (\Exception $e) {
+          $this->logger->error('Error deleting hearing replies on hearing @label (@id): @message', [
+            '@id' => $node->id(),
+            '@label' => $node->label(),
+            '@message' => $e->getMessage(),
+          ]);
+        }
+      }
+    }
+  }
+
+  /**
    * Set Deskpro data for a node.
    *
    * @param \Drupal\node\Entity\NodeInterface $node

--- a/web/modules/custom/hoeringsportal_deskpro/templates/block/hoeringsportal-hearing-tickets.html.twig
+++ b/web/modules/custom/hoeringsportal_deskpro/templates/block/hoeringsportal-hearing-tickets.html.twig
@@ -40,18 +40,18 @@
 
   {% else %}
 
-    {% if is_delete_replies_date_passed %}
-      {# Deleted tickets information #}
-        <div class="col-md-12 q">
-          <div class="alert alert-warning mb-3 d-flex gap-3" role="alert">
-            <i class="fa-solid fa-triangle-exclamation fa-xl"></i>
-            <div>
-              <h4 class="mt-0">{{ 'The hearing replies are deleted'|trans }}</h4>
-              <p class="mb-0">{{ 'The time limit for how long we are allowed to keep the replies has been reached so we where obligated to delete them.'|trans }}</p>
-            </div>
+    {% if hearing_replies_deleted_on %}
+      {%  set date = hearing_replies_deleted_on|date('U')|format_date('hoeringsportal_date') %}
+      <div class="col-md-12 q">
+        <div class="alert alert-warning mb-3 d-flex gap-3" role="alert">
+          <i class="fa-solid fa-triangle-exclamation fa-xl"></i>
+          <div>
+            <h4 class="mt-0">{{ 'The hearing replies were deleted on @date'|trans({'@date': date}) }}</h4>
+            <p class="mb-0">{{ 'The time limit for how long we are allowed to keep the replies has been reached so we where obligated to delete them.'|trans }}</p>
           </div>
-          <p>{{ 'You can <a href="/">read more about why and how we delete old tickets</a>'|trans }}</p>
         </div>
+        <p>{{ 'You can <a href="/">read more about why and how we delete old hearing replies</a>'|trans }}</p>
+      </div>
 
     {% else %}
     <div class="row mb-3">

--- a/web/modules/custom/hoeringsportal_deskpro/templates/block/hoeringsportal-hearing-tickets.html.twig
+++ b/web/modules/custom/hoeringsportal_deskpro/templates/block/hoeringsportal-hearing-tickets.html.twig
@@ -40,6 +40,20 @@
 
   {% else %}
 
+    {% if is_delete_replies_date_passed %}
+      {# Deleted tickets information #}
+        <div class="col-md-12 q">
+          <div class="alert alert-warning mb-3 d-flex gap-3" role="alert">
+            <i class="fa-solid fa-triangle-exclamation fa-xl"></i>
+            <div>
+              <h4 class="mt-0">{{ 'The hearing replies are deleted'|trans }}</h4>
+              <p class="mb-0">{{ 'The time limit for how long we are allowed to keep the replies has been reached so we where obligated to delete them.'|trans }}</p>
+            </div>
+          </div>
+          <p>{{ 'You can <a href="/">read more about why and how we delete old tickets</a>'|trans }}</p>
+        </div>
+
+    {% else %}
     <div class="row mb-3">
       <div class="col-md-6">
         {% if hearing_ticket_list_url %}
@@ -80,20 +94,7 @@
       {% endfor %}
     {% endif %}
 
-  {% endif %}
-
-  {# Deleted tickets information #}
-  {% if node.field_delete_date.value < "now"|date('Y-m-d') %}
-    <div class="col-md-12 q">
-      <div class="alert alert-warning mb-3 d-flex gap-3" role="alert">
-          <i class="fa-solid fa-triangle-exclamation fa-xl"></i>
-          <div>
-            <h4 class="mt-0">{{ 'The hearing tickets is deleted'|trans }}</h4>
-            <p class="mb-0">{{ 'The time limit for how long we are allowed to kkep the tickets have been reached so we where obligated to delete them.'|trans }}</p>
-          </div>
-      </div>
-      <p>{{ 'You can <a href="/">read more about why and how we delete old tickets</a>'|trans }}</p>
-    </div>
+    {% endif %}
   {% endif %}
 
 </div>

--- a/web/modules/custom/hoeringsportal_hearing/modules/hoeringsportal_hearing_fixtures/src/Fixture/HearingFixture.php
+++ b/web/modules/custom/hoeringsportal_hearing/modules/hoeringsportal_hearing_fixtures/src/Fixture/HearingFixture.php
@@ -6,6 +6,7 @@ use Drupal\content_fixtures\Fixture\AbstractFixture;
 use Drupal\content_fixtures\Fixture\DependentFixtureInterface;
 use Drupal\content_fixtures\Fixture\FixtureGroupInterface;
 use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
 use Drupal\hoeringsportal_base_fixtures\Fixture\MediaFixture;
 use Drupal\hoeringsportal_base_fixtures\Fixture\ParagraphFixture;
 use Drupal\node\Entity\Node;
@@ -102,6 +103,11 @@ Lorem ipsum 1234 Lorem ipsum',
 EOD,
       'format' => 'hearing_description',
     ]);
+    $entity->save();
+
+    $entity = $entity->createDuplicate();
+    $entity->setTitle('Høring med slettede høringssvar');
+    $entity->set('field_delete_date', (new DrupalDateTime('2001-01-01'))->format(DateTimeItemInterface::DATE_STORAGE_FORMAT));
     $entity->save();
   }
 


### PR DESCRIPTION
https://leantime.itkdev.dk/dashboard/home#/tickets/showTicket/2456

Builds on the excellent work in https://github.com/itk-dev/hoeringsportal/pull/418.

* Adds Drush command to actually delete replies from hearings with a “delete date” in the past.
* Removes unused database table (`hoeringsportal_deskpro_deskpro_data`)