### PR TITLE
1606: Made supporter name optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-420](https://github.com/itk-dev/hoeringsportal/pull/420)
+  1606: Made supporter name optional
 * [PR-419](https://github.com/itk-dev/hoeringsportal/pull/419)
   Added Drush command to delete hearing replies
 * [PR-418](https://github.com/itk-dev/hoeringsportal/pull/418)

--- a/web/modules/custom/hoeringsportal_citizen_proposal/src/Form/ProposalFormSupport.php
+++ b/web/modules/custom/hoeringsportal_citizen_proposal/src/Form/ProposalFormSupport.php
@@ -83,17 +83,6 @@ final class ProposalFormSupport extends ProposalFormBase {
 
     ];
 
-    $form['name'] = [
-      '#type' => 'textfield',
-      '#required' => TRUE,
-      '#title' => $this
-        ->t('Name'),
-      '#default_value' => $defaltValues['name'],
-      '#attributes' => ['readonly' => !$this->isAuthenticatedAsEditor()],
-      '#description' => $this->getAdminFormStateValue('support_name_help'),
-      '#description_display' => 'before',
-    ];
-
     $form['email'] = [
       '#type' => 'email',
       '#title' => $this
@@ -115,6 +104,22 @@ final class ProposalFormSupport extends ProposalFormBase {
         ],
       ],
     ];
+
+    $form['name'] = [
+      '#type' => 'textfield',
+      '#title' => $this
+        ->t('Name'),
+      '#default_value' => $defaltValues['name'],
+      '#attributes' => ['readonly' => !$this->isAuthenticatedAsEditor()],
+      '#description' => $this->getAdminFormStateValue('support_name_help'),
+      '#description_display' => 'before',
+      '#states' => [
+        'required' => [
+          ':input[name="allow_email"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+    $form['name']['#states']['visible'] = $form['name']['#states']['required'];
 
     $this->buildSurveyForm($form);
 


### PR DESCRIPTION
https://leantime.itkdev.dk/dashboard/home?tab=ticketdetails#/tickets/showTicket/1606

Moves form fields around and makes “Name” visible (and required) only when requesting emails.

Before:

![Screen Shot 2024-10-07 at 09 10 50](https://github.com/user-attachments/assets/1e5acad2-d1d0-4258-9c06-797ba5a91150)

After:

![Screen Shot 2024-10-07 at 09 09 34](https://github.com/user-attachments/assets/bb1d6a0c-d3dc-4025-bb35-32a60fe272bb)
![Screen Shot 2024-10-07 at 09 09 48](https://github.com/user-attachments/assets/88d07a42-a477-474a-9c25-30278085f332)

