### PR TITLE
add usable config values for oidc

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -2,7 +2,7 @@
 	"default": true,
 	// https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md
 	"line-length": {
-		"line_length": 80,
+		"line_length": 120,
 		"code_blocks": false,
 		"tables": false
 	},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 * [PR-435](https://github.com/itk-dev/hoeringsportal/pull/435)
-  add usable config values for oidc
+  Add usable config values for oidc
+  Update OIDC documentation
+  Rename editor user in group "administrator" to admin user
 * [PR-433](https://github.com/itk-dev/hoeringsportal/pull/433)
   Upgrade node from 18 to 22
 * [PR-432](https://github.com/itk-dev/hoeringsportal/pull/432)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-435](https://github.com/itk-dev/hoeringsportal/pull/435)
+  add usable config values for oidc
 * [PR-433](https://github.com/itk-dev/hoeringsportal/pull/433)
   Upgrade node from 18 to 22
 * [PR-432](https://github.com/itk-dev/hoeringsportal/pull/432)

--- a/config/sync/openid_connect.client.generic.yml
+++ b/config/sync/openid_connect.client.generic.yml
@@ -6,11 +6,12 @@ id: generic
 label: generic
 plugin: generic
 settings:
-  client_id: "file:///settings.local.php#$config['openid_connect.client.generic']['settings']['client_id']"
-  client_secret: "file:///settings.local.php#$config['openid_connect.client.generic']['settings']['client_secret']"
+  client_id: client-id
+  client_secret: client-secret
+  iss_allowed_domains: ''
   issuer_url: ''
-  authorization_endpoint: "file:///settings.local.php#$config['openid_connect.client.generic']['settings']['client_id']"
-  token_endpoint: "file:///settings.local.php#$config['openid_connect.client.generic']['settings']['token_endpoint']"
+  authorization_endpoint: 'http://idp-employee.hoeringsportal.local.itkdev.dk/connect/authorize'
+  token_endpoint: 'http://idp-employee.hoeringsportal.local.itkdev.dk/connect/token'
   userinfo_endpoint: ''
   end_session_endpoint: ''
   scopes:

--- a/docker-compose.oidc.yml
+++ b/docker-compose.oidc.yml
@@ -269,15 +269,15 @@ services:
 
       USERS_CONFIGURATION_INLINE: |
         - SubjectId: 1
-          Username: department1-editor
-          Password: department1-editor
+          Username: department1-admin
+          Password: department1-admin
           Claims:
             # Claims added here must be defined above in IDENTITY_RESOURCES_INLINE
           - Type: email
-            Value: 'department1-editor@example.com'
+            Value: 'department1-admin@example.com'
             ValueType: string
           - Type: name
-            Value: 'department1-editor'
+            Value: 'department1-admin'
             ValueType: string
           - Type: magistratsafdeling
             Value: 'Department 1'

--- a/documentation/openIdConnect.md
+++ b/documentation/openIdConnect.md
@@ -21,8 +21,8 @@ $settings['locale_custom_strings_da'][''] = [
 ];
 ```
 
-Use `drush` to check your actual configuration (with `--include-overridden` to
-include your config from `settings.local.php`):
+Use `drush` to check your actual configuration (with `--include-overridden` to include your config from
+`settings.local.php`):
 
 ```sh
 docker compose exec phpfpm vendor/bin/drush config:get --include-overridden openid_connect.client.generic
@@ -31,13 +31,11 @@ docker compose exec phpfpm vendor/bin/drush config:get --include-overridden open
 
 ## Citizen authentification
 
-See the [Høringsportalen OpenID Connect
-module](../web/modules/custom/hoeringsportal_openid_connect/README.md) for
+See the [Høringsportalen OpenID Connect module](../web/modules/custom/hoeringsportal_openid_connect/README.md) for
 details on configuring OpenID Connect authentification for citizens.
 
-For local testing we use [OpenId Connect Server
-Mock](https://github.com/Soluto/oidc-server-mock) for (almost) real OpenID
-Connect. Users and their claims are defined in
+For local testing we use [OpenId Connect Server Mock](https://github.com/Soluto/oidc-server-mock) for (almost) real
+OpenID Connect. Users and their claims are defined in
 [`docker-compose.override.yml`](../../../../docker-compose.override.yml).
 
 ## Employee authentification
@@ -61,16 +59,31 @@ docker compose exec phpfpm vendor/bin/drush php:eval "\Drupal\taxonomy\Entity\Te
 docker compose --profile oidc up --detach
 ```
 
-During development it can be useful to see the user info we actually get during
-OpenID Connect authentification, and to do this you can apply the patch
-[openid_connect-debug-userinfo.patch](../patches/openid_connect-debug-userinfo.patch):
+### Local OIDC test
+
+During (local) development we use [OpenId Connect Server Mock](https://github.com/Soluto/oidc-server-mock) (cf.
+[`docker-compose.oidc.yml`](docker-compose.oidc.yml) which is
+[included](https://docs.docker.com/compose/how-tos/multiple-compose-files/include/) in
+[`docker-compose.override.yml`](docker-compose.override.yml)).
+
+#### Employees
+
+| Username            | Password             | Groups        |
+|---------------------|----------------------|---------------|
+| department1-admin   | department1-admin    | administrator |
+| department2-editor  | department2-editor   | editor        |
+| department3-editor  | department3-editor   | editor        |
+
+## Debug OIDC
+
+During development it can be useful to see the user info we actually get during OpenID Connect authentification, and to
+do this you can apply the patch [openid_connect-debug-userinfo.patch](../patches/openid_connect-debug-userinfo.patch):
 
 ```sh
 docker compose exec phpfpm patch --strip=1 --input=patches/openid_connect-debug-userinfo.patch
 ```
 
-After applying the patch and succesfully logging in, the actual userinfo
-received can be inspected with
+After applying the patch and succesfully logging in, the actual userinfo received can be inspected with
 
 ```sh
 docker compose exec phpfpm vendor/bin/drush watchdog:show --type=itkdev-debug --extended


### PR DESCRIPTION
- Add config for oidc and 
- Add documentation of users (some of it stolen from [ai-screening](https://github.com/itk-dev/ai-screening/blob/df0ffe693a061daa50e89187db81c9c819a8f126/docs/Development.md#L16)
- Rename `department1-editor` to `department1-admin` as it was in the group "administrator"
