### PR TITLE
Update person name in Deskpro on email match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-455](https://github.com/itk-dev/hoeringsportal/pull/455)
+  * Fixed bug in display of "on behalf of” on hearing reply details
+  * Added "on behalf of” on hearing reply list
+  * Corrected handling of ticket creation time
 * [PR-454](https://github.com/itk-dev/hoeringsportal/pull/454)
   Update person name in Deskpro on email match
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-454](https://github.com/itk-dev/hoeringsportal/pull/454)
+  Update person name in Deskpro on email match
+
 ## [4.6.5] - 2025-03-05
 
 * [PR-456](https://github.com/itk-dev/hoeringsportal/pull/456)

--- a/web/modules/custom/hoeringsportal_deskpro/hoeringsportal_deskpro.install
+++ b/web/modules/custom/hoeringsportal_deskpro/hoeringsportal_deskpro.install
@@ -363,3 +363,29 @@ function hoeringsportal_deskpro_update_8005(&$sandbox) {
   $schema = $connection->schema();
   $schema->dropTable('hoeringsportal_deskpro_deskpro_data');
 }
+
+/**
+ * Update created_at on Deskpro tickets based on ticket data.
+ */
+function hoeringsportal_deskpro_update_10001(&$sandbox) {
+  /** @var \Drupal\Core\Database\Connection $connection */
+  $connection = \Drupal::service('database');
+  $connection
+    ->query(<<<'SQL'
+UPDATE
+  hoeringsportal_deskpro_deskpro_tickets
+SET
+  created_at = STR_TO_DATE(
+    -- Remove timezone from datetime string
+    REPLACE(
+      -- Extract date_created from ticket as a string
+      CAST(JSON_VALUE(data, '$.date_created') AS VARCHAR(255)),
+      '+0000',
+      ''
+    ),
+    '%Y-%m-%dT%H:%i:%s'
+  )
+SQL
+  )
+    ->execute();
+}

--- a/web/modules/custom/hoeringsportal_deskpro/src/Form/HearingTicketAddForm.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/Form/HearingTicketAddForm.php
@@ -72,7 +72,7 @@ final class HearingTicketAddForm extends FormBase {
       '#value' => $this->config->get('intro'),
     ];
 
-    $form['name'] = [
+    $form['person_name'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Your full name'),
       '#required' => TRUE,
@@ -225,10 +225,10 @@ final class HearingTicketAddForm extends FormBase {
 
     parent::validateForm($form, $form_state);
 
-    if ($name = $form_state->getValue('name')) {
+    if ($name = $form_state->getValue('person_name')) {
       // @see https://www.php.net/manual/en/regexp.reference.unicode.php
       if (preg_match('/\p{N}/u', $name)) {
-        $form_state->setErrorByName('name', $this->t('Your name cannot contain numbers.'));
+        $form_state->setErrorByName('person_name', $this->t('Your name cannot contain numbers.'));
       }
     }
 
@@ -265,7 +265,7 @@ final class HearingTicketAddForm extends FormBase {
     $this->initialize();
 
     $names = [
-      'name',
+      'person_name',
       'email',
       'address_secret',
       'postal_code',

--- a/web/modules/custom/hoeringsportal_deskpro/src/Service/HearingHelper.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/Service/HearingHelper.php
@@ -176,6 +176,11 @@ class HearingHelper {
         return $this->fileSystem->realpath($file->getFileUri());
       }, File::loadMultiple($fileIds));
 
+      // The Deskpro service expects a person name under the 'name' key.
+      if (isset($data['person_name'])) {
+        $data['name'] = $data['person_name'];
+      }
+
       // Map data to custom fields.
       $customFields = $this->deskpro->getTicketCustomFields();
       foreach ($data as $key => $value) {

--- a/web/modules/custom/hoeringsportal_deskpro/src/Service/HearingHelper.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/Service/HearingHelper.php
@@ -385,14 +385,14 @@ class HearingHelper {
       $keys['ticket_id'] = $ticket['id'];
       $fields['email'] = $ticket['person_email'];
       $fields['data'] = json_encode($ticket);
+      $fields['created_at'] = (new DrupalDateTime($ticket['date_created']))->format(DrupalDateTime::FORMAT);
 
       $result = $this->database->merge('hoeringsportal_deskpro_deskpro_tickets')
         ->keys($keys)
         ->updateFields($fields)
         ->insertFields(
-          $keys + $fields + [
-            'created_at' => $fields['updated_at'],
-          ])
+          $keys + $fields
+        )
         ->execute();
     }
 
@@ -496,6 +496,7 @@ class HearingHelper {
         else {
           $fields = [
             'updated_at' => (new DrupalDateTime())->format(DrupalDateTime::FORMAT),
+            'created_at' => (new DrupalDateTime($ticket['date_created']))->format(DrupalDateTime::FORMAT),
             'email' => $ticket['person_email'],
             'data' => json_encode($ticket),
           ];
@@ -504,9 +505,7 @@ class HearingHelper {
             ->keys($keys)
             ->updateFields($fields)
             ->insertFields(
-              $keys + $fields + [
-                'created_at' => $fields['updated_at'],
-              ])
+              $keys + $fields)
             ->execute();
 
           $this->logger->debug(

--- a/web/modules/custom/hoeringsportal_deskpro/src/State/DeskproConfig.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/State/DeskproConfig.php
@@ -63,6 +63,7 @@ class DeskproConfig extends DatabaseStorage {
     'edoc_id' => 'eDoc id',
     'getorganized_case_id' => 'GetOrganized case id',
     'pdf_download_url' => 'PDF download url',
+    'person_name' => 'Person name',
     'representation' => 'Representation',
     'organization' => 'Organization (used with representation)',
     'address_secret' => 'Address is secret',

--- a/web/modules/custom/hoeringsportal_deskpro/src/Twig/TwigExtension.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/Twig/TwigExtension.php
@@ -75,12 +75,27 @@ class TwigExtension extends AbstractExtension {
    * Get ticket custom field value.
    */
   public function getTicketCustomField(array $ticket, string $field) {
-    $config = $this->helper->getDeskproConfig();
+    // Get actual representation used on a ticket.
+    $getRepresentation = function () use ($ticket): ?array {
+      $config = $this->helper->getDeskproConfig();
+      $representations = $config->getRepresentations();
+
+      $index = array_key_first((array) ($ticket['fields']['representation'] ?? []));
+
+      return $representations[$index] ?? NULL;
+    };
 
     if ('representation' === $field) {
-      $representations = $config->getRepresentations();
-      $index = $ticket['fields'][$field][0] ?? NULL;
-      return $representations[$index]['title'] ?? NULL;
+      return $getRepresentation()['title'] ?? NULL;
+    }
+
+    if ('organization' === $field) {
+      $representation = $getRepresentation();
+
+      return ($representation['require_organization'] ?? FALSE)
+        // Organization may not actually be set on ticket (!)
+        ? ($ticket['fields'][$field] ?? NULL)
+        : NULL;
     }
 
     return $ticket['fields'][$field] ?? NULL;

--- a/web/modules/custom/hoeringsportal_deskpro/templates/block/hoeringsportal-hearing-tickets.html.twig
+++ b/web/modules/custom/hoeringsportal_deskpro/templates/block/hoeringsportal-hearing-tickets.html.twig
@@ -82,7 +82,20 @@
             {{ message|length > 180 ? message|slice(0, 180)|raw ~ '…' : message|raw }}
           </div>
           <div class="card-footer">
-            {{ '@ticket_ref by @person_name'|trans({'@ticket_ref': ticket.ref, '@person_name': ticket.fields.person_name|default(ticket.person.display_name)}) }}
+            {% set person_name = ticket.fields.person_name|default(ticket.person.display_name) %}
+            {% set organization_type = deskpro_ticket_custom_field(ticket, 'representation') %}
+            {% set organization = deskpro_ticket_custom_field(ticket, 'organization') %}
+
+            {% if organization_type and organization %}
+              {{ '@ticket_ref by @person_name on behalf of @organization (@organization_type)'|trans({
+                '@ticket_ref': ticket.ref,
+                '@person_name': person_name,
+                '@organization': organization,
+                '@organization_type': organization_type,
+                }) }}
+            {% else %}
+              {{ '@ticket_ref by @person_name'|trans({'@ticket_ref': ticket.ref, '@person_name': person_name}) }}
+            {% endif %}
             | <span class="ticket-date_created">{{ ticket.date_created|date('U')|format_date('hoeringsportal_datetime') }}</span>
             <i class="fa fa-arrow-right float-right"></i>
           </div>

--- a/web/modules/custom/hoeringsportal_deskpro/templates/block/hoeringsportal-hearing-tickets.html.twig
+++ b/web/modules/custom/hoeringsportal_deskpro/templates/block/hoeringsportal-hearing-tickets.html.twig
@@ -82,7 +82,7 @@
             {{ message|length > 180 ? message|slice(0, 180)|raw ~ '…' : message|raw }}
           </div>
           <div class="card-footer">
-            {{ '@ticket_ref by @person_name'|trans({'@ticket_ref': ticket.ref, '@person_name': ticket.person.display_name}) }}
+            {{ '@ticket_ref by @person_name'|trans({'@ticket_ref': ticket.ref, '@person_name': ticket.fields.person_name|default(ticket.person.display_name)}) }}
             | <span class="ticket-date_created">{{ ticket.date_created|date('U')|format_date('hoeringsportal_datetime') }}</span>
             <i class="fa fa-arrow-right float-right"></i>
           </div>


### PR DESCRIPTION
#### Link to ticket

<https://leantime.itkdev.dk/TimeTable/TimeTable?showTicketModal=3913#/tickets/showTicket/3913>

#### Description

Updates person name in Deskpro if email matches an already existing email. If not doing this, the old name will be used for the person posting a hearing reply.

> [!CAUTION]
> It's still unclear if this should be released as a hotfix or via merge to `develop`.

