### PR TITLE
Added fixture helper command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-476](https://github.com/itk-dev/hoeringsportal/pull/476)
+  Added fixture helper command
 * [PR-475](https://github.com/itk-dev/hoeringsportal/pull/475)
   * New landingpage hero
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-475](https://github.com/itk-dev/hoeringsportal/pull/475)
+  * New landingpage hero
+
 * [PR-472](https://github.com/itk-dev/hoeringsportal/pull/472)
   * Translated search page to Danish
   * Updated custom Danish translations (exported from production site)

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,8 @@
         "drupal/redirect": "^1.6",
         "drupal/search_api": "^1.37",
         "drupal/search_autocomplete": "^3.0",
+        "drupal/svg_image": "^3.2",
+        "drupal/svg_sanitizer": "^2.0",
         "drupal/token_filter": "^2.1",
         "drupal/toolbar_visibility": "^2.1",
         "drupal/twig_tweak": "^3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "29503f28c0629e2d84a83d4c8935ec28",
+    "content-hash": "587044f76682b68cdba384992a3aae69",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4942,6 +4942,122 @@
             }
         },
         {
+            "name": "drupal/svg_image",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/svg_image.git",
+                "reference": "3.2.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/svg_image-3.2.1.zip",
+                "reference": "3.2.1",
+                "shasum": "4623b9d0de4c624857df10daaa8c68793942ad87"
+            },
+            "require": {
+                "drupal/core": "^10.3 || ^11",
+                "enshrined/svg-sanitize": ">=0.15 <1.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.2.1",
+                    "datestamp": "1736865227",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Yaroslav Lushnikov",
+                    "homepage": "https://www.drupal.org/u/imyaro",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "See contributors",
+                    "homepage": "https://www.drupal.org/node/2887125/committers"
+                },
+                {
+                    "name": "imyaro",
+                    "homepage": "https://www.drupal.org/user/2870933"
+                },
+                {
+                    "name": "mably",
+                    "homepage": "https://www.drupal.org/user/3375160"
+                },
+                {
+                    "name": "thomas.frobieter",
+                    "homepage": "https://www.drupal.org/user/409335"
+                }
+            ],
+            "description": "Overrides the standard image formatter and widget to support SVG files.",
+            "homepage": "https://drupal.org/project/svg_image",
+            "support": {
+                "source": "https://git.drupalcode.org/project/svg_image",
+                "issues": "https://www.drupal.org/project/issues/svg_image"
+            }
+        },
+        {
+            "name": "drupal/svg_sanitizer",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/svg_sanitizer.git",
+                "reference": "2.0.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/svg_sanitizer-2.0.2.zip",
+                "reference": "2.0.2",
+                "shasum": "24c3bfec0c5717b35b5302bfdcf75d67c2c7c9ad"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10 || ^11",
+                "enshrined/svg-sanitize": "~0.13"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.2",
+                    "datestamp": "1721261176",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL2+"
+            ],
+            "authors": [
+                {
+                    "name": "heyMP",
+                    "homepage": "https://www.drupal.org/user/466258"
+                },
+                {
+                    "name": "larowlan",
+                    "homepage": "https://www.drupal.org/user/395439"
+                },
+                {
+                    "name": "pasan.gamage",
+                    "homepage": "https://www.drupal.org/user/3527697"
+                }
+            ],
+            "description": "Makes the SVG Sanitizer library available to Drupal",
+            "homepage": "https://www.drupal.org/project/svg_sanitizer",
+            "support": {
+                "source": "https://git.drupalcode.org/project/svg_sanitizer"
+            }
+        },
+        {
             "name": "drupal/symfony_mailer",
             "version": "1.5.0",
             "source": {
@@ -5819,6 +5935,51 @@
                 }
             ],
             "time": "2024-12-27T00:36:43+00:00"
+        },
+        {
+            "name": "enshrined/svg-sanitize",
+            "version": "0.21.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/darylldoyle/svg-sanitizer.git",
+                "reference": "5e477468fac5c5ce933dce53af3e8e4e58dcccc9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/5e477468fac5c5ce933dce53af3e8e4e58dcccc9",
+                "reference": "5e477468fac5c5ce933dce53af3e8e4e58dcccc9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5 || ^8.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "enshrined\\svgSanitize\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Daryll Doyle",
+                    "email": "daryll@enshrined.co.uk"
+                }
+            ],
+            "description": "An SVG sanitizer for PHP",
+            "support": {
+                "issues": "https://github.com/darylldoyle/svg-sanitizer/issues",
+                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.21.0"
+            },
+            "time": "2025-01-13T09:32:25+00:00"
         },
         {
             "name": "firebase/php-jwt",

--- a/config/sync/core.entity_form_display.media.icon.default.yml
+++ b/config/sync/core.entity_form_display.media.icon.default.yml
@@ -1,0 +1,69 @@
+uuid: d9a4d59d-d056-407d-88de-0f49890bb455
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.field.media.icon.field_itk_media_image_upload
+    - image.style.thumbnail
+    - media.type.icon
+  module:
+    - image
+    - path
+id: media.icon.default
+targetEntityType: media
+bundle: icon
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_itk_media_image_upload:
+    type: image_image
+    weight: 0
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 100
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_form_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.landing_page.default.yml
@@ -6,12 +6,14 @@ dependencies:
     - entity_browser.browser.itk_image_browser
     - field.field.node.landing_page.field_media_image_single
     - field.field.node.landing_page.field_section
+    - field.field.node.landing_page.field_show_page_title
     - field.field.node.landing_page.field_teaser
     - node.type.landing_page
   module:
     - entity_browser
     - paragraphs
     - path
+    - publication_date
 id: node.landing_page.default
 targetEntityType: node
 bundle: landing_page
@@ -19,7 +21,7 @@ mode: default
 content:
   field_media_image_single:
     type: entity_browser_entity_reference
-    weight: 2
+    weight: 3
     region: content
     settings:
       entity_browser: itk_image_browser
@@ -34,7 +36,7 @@ content:
     third_party_settings: {  }
   field_section:
     type: entity_reference_paragraphs
-    weight: 3
+    weight: 4
     region: content
     settings:
       title: sektion
@@ -44,9 +46,16 @@ content:
       form_display_mode: default
       default_paragraph_type: _none
     third_party_settings: {  }
+  field_show_page_title:
+    type: boolean_checkbox
+    weight: 1
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_teaser:
     type: string_textarea
-    weight: 1
+    weight: 2
     region: content
     settings:
       rows: 5
@@ -54,19 +63,19 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   published_at:
     type: publication_date_timestamp
-    weight: 10
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 6
+    weight: 7
     region: content
     settings:
       display_label: true
@@ -81,7 +90,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 4
+    weight: 5
     region: content
     settings:
       match_operator: CONTAINS
@@ -90,7 +99,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 50
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.paragraph.link.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.link.default.yml
@@ -1,0 +1,52 @@
+uuid: 5279d8f6-eefe-4280-97da-89b91f1be541
+langcode: da
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.itk_icon_browser
+    - field.field.paragraph.link.field_decorative_arrow
+    - field.field.paragraph.link.field_icon
+    - field.field.paragraph.link.field_link
+    - paragraphs.paragraphs_type.link
+  module:
+    - entity_browser
+id: paragraph.link.default
+targetEntityType: paragraph
+bundle: link
+mode: default
+content:
+  field_decorative_arrow:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_icon:
+    type: entity_browser_entity_reference
+    weight: 0
+    region: content
+    settings:
+      entity_browser: itk_icon_browser
+      field_widget_display: rendered_entity
+      field_widget_edit: false
+      field_widget_remove: true
+      field_widget_replace: false
+      open: true
+      field_widget_display_settings:
+        view_mode: node_form_display
+      selection_mode: selection_append
+    third_party_settings: {  }
+  field_link:
+    type: entity_reference_autocomplete_tags
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 100
+      placeholder: 'Search the name of the page'
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/sync/core.entity_form_display.paragraph.links_on_a_background_image.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.links_on_a_background_image.default.yml
@@ -1,0 +1,53 @@
+uuid: 7535122a-4121-461d-b632-e38976307366
+langcode: da
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.itk_image_browser
+    - field.field.paragraph.links_on_a_background_image.field_links_list
+    - field.field.paragraph.links_on_a_background_image.field_paragraph_image
+    - paragraphs.paragraphs_type.links_on_a_background_image
+  module:
+    - entity_browser
+    - paragraphs
+id: paragraph.links_on_a_background_image.default
+targetEntityType: paragraph
+bundle: links_on_a_background_image
+mode: default
+content:
+  field_links_list:
+    type: paragraphs
+    weight: 3
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+  field_paragraph_image:
+    type: entity_browser_entity_reference
+    weight: 2
+    region: content
+    settings:
+      entity_browser: itk_image_browser
+      field_widget_display: rendered_entity
+      field_widget_edit: false
+      field_widget_remove: true
+      field_widget_replace: false
+      open: true
+      field_widget_display_settings:
+        view_mode: node_form_display
+      selection_mode: selection_append
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/sync/core.entity_view_display.media.icon.default.yml
+++ b/config/sync/core.entity_view_display.media.icon.default.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - field.field.media.icon.field_itk_media_image_upload
-    - image.style.thumbnail
     - media.type.icon
   module:
     - svg_image
@@ -15,16 +14,16 @@ mode: default
 content:
   field_itk_media_image_upload:
     type: image
-    label: visually_hidden
+    label: hidden
     settings:
       image_link: ''
-      image_style: thumbnail
+      image_style: ''
       image_loading:
         attribute: lazy
       svg_attributes:
         width: null
         height: null
-      svg_render_as_image: true
+      svg_render_as_image: false
     third_party_settings: {  }
     weight: 0
     region: content

--- a/config/sync/core.entity_view_display.media.icon.default.yml
+++ b/config/sync/core.entity_view_display.media.icon.default.yml
@@ -1,0 +1,37 @@
+uuid: 8d0484ff-c4a8-45a0-833e-023e34b81688
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.field.media.icon.field_itk_media_image_upload
+    - image.style.thumbnail
+    - media.type.icon
+  module:
+    - svg_image
+id: media.icon.default
+targetEntityType: media
+bundle: icon
+mode: default
+content:
+  field_itk_media_image_upload:
+    type: image
+    label: visually_hidden
+    settings:
+      image_link: ''
+      image_style: thumbnail
+      image_loading:
+        attribute: lazy
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/config/sync/core.entity_view_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.landing_page.field_media_image_single
     - field.field.node.landing_page.field_section
+    - field.field.node.landing_page.field_show_page_title
     - field.field.node.landing_page.field_teaser
     - node.type.landing_page
   module:
@@ -33,6 +34,7 @@ third_party_settings:
         - field_section
         - field_teaser
         - field_media_image_single
+        - field_show_page_title
 id: node.landing_page.default
 targetEntityType: node
 bundle: landing_page
@@ -57,6 +59,16 @@ content:
       ds:
         ds_limit: ''
     weight: 0
+    region: ds_content
+  field_show_page_title:
+    type: boolean
+    label: hidden
+    settings:
+      format: boolean
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 3
     region: ds_content
   field_teaser:
     type: basic_string

--- a/config/sync/core.entity_view_display.node.landing_page.list_display.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.list_display.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.list_display
     - field.field.node.landing_page.field_media_image_single
     - field.field.node.landing_page.field_section
+    - field.field.node.landing_page.field_show_page_title
     - field.field.node.landing_page.field_teaser
     - node.type.landing_page
   module:
@@ -35,6 +36,7 @@ content:
     region: content
 hidden:
   field_media_image_single: true
+  field_show_page_title: true
   field_teaser: true
   langcode: true
   links: true

--- a/config/sync/core.entity_view_display.node.landing_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.landing_page.field_media_image_single
     - field.field.node.landing_page.field_section
+    - field.field.node.landing_page.field_show_page_title
     - field.field.node.landing_page.field_teaser
     - node.type.landing_page
   module:
@@ -26,6 +27,7 @@ content:
 hidden:
   field_media_image_single: true
   field_section: true
+  field_show_page_title: true
   field_teaser: true
   langcode: true
   published_at: true

--- a/config/sync/core.entity_view_display.node.public_meeting.default.yml
+++ b/config/sync/core.entity_view_display.node.public_meeting.default.yml
@@ -131,8 +131,10 @@ third_party_settings:
       weight: 9
       format_type: html_element
       format_settings:
-        classes: 'container pt-5 pb-3 position-relative'
+        classes: ''
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: true
         label_element: h2

--- a/config/sync/core.entity_view_display.paragraph.link.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.link.default.yml
@@ -16,7 +16,7 @@ content:
     type: boolean
     label: hidden
     settings:
-      format: default
+      format: boolean
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
@@ -26,16 +26,15 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: default
+      view_mode: full
       link: false
     third_party_settings: {  }
     weight: 0
     region: content
   field_link:
-    type: entity_reference_entity_view
+    type: entity_reference_label
     label: hidden
     settings:
-      view_mode: default
       link: true
     third_party_settings: {  }
     weight: 1

--- a/config/sync/core.entity_view_display.paragraph.link.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.link.default.yml
@@ -1,0 +1,44 @@
+uuid: f2a5d3e8-499e-40ca-b111-cd9bf2a03a56
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.link.field_decorative_arrow
+    - field.field.paragraph.link.field_icon
+    - field.field.paragraph.link.field_link
+    - paragraphs.paragraphs_type.link
+id: paragraph.link.default
+targetEntityType: paragraph
+bundle: link
+mode: default
+content:
+  field_decorative_arrow:
+    type: boolean
+    label: hidden
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_icon:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_link:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: true
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.links_on_a_background_image.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.links_on_a_background_image.default.yml
@@ -1,0 +1,35 @@
+uuid: e4a41100-e808-4611-b9fe-c82e6127300e
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.links_on_a_background_image.field_links_list
+    - field.field.paragraph.links_on_a_background_image.field_paragraph_image
+    - paragraphs.paragraphs_type.links_on_a_background_image
+  module:
+    - entity_reference_revisions
+id: paragraph.links_on_a_background_image.default
+targetEntityType: paragraph
+bundle: links_on_a_background_image
+mode: default
+content:
+  field_links_list:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_paragraph_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: full
+      link: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.links_on_a_background_image.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.links_on_a_background_image.default.yml
@@ -15,7 +15,7 @@ mode: default
 content:
   field_links_list:
     type: entity_reference_revisions_entity_view
-    label: above
+    label: hidden
     settings:
       view_mode: default
       link: ''

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -94,6 +94,8 @@ module:
   search_api_db: 0
   search_autocomplete: 0
   serialization: 0
+  svg_image: 0
+  svg_sanitizer: 0
   symfony_mailer: 0
   system: 0
   taxonomy: 0

--- a/config/sync/entity_browser.browser.itk_icon_browser.yml
+++ b/config/sync/entity_browser.browser.itk_icon_browser.yml
@@ -1,0 +1,48 @@
+uuid: fcbd3c6d-87ee-4c16-8c8f-e1ac0552e64a
+langcode: da
+status: true
+dependencies:
+  config:
+    - views.view.itk_media_browser
+  module:
+    - entity_browser_entity_form
+    - views
+name: itk_icon_browser
+label: 'ITK icon browser'
+display: modal
+display_configuration:
+  width: ''
+  height: ''
+  link_text: 'Vælg ikon'
+  auto_open: false
+selection_display: multi_step_display
+selection_display_configuration:
+  entity_type: media
+  display: rendered_entity
+  display_settings:
+    view_mode: default
+  select_text: 'Use selected'
+  selection_hidden: false
+widget_selector: tabs
+widget_selector_configuration: {  }
+widgets:
+  a9859c97-cfd7-44ef-9da9-fabc75436b4e:
+    id: view
+    uuid: a9859c97-cfd7-44ef-9da9-fabc75436b4e
+    label: Overblik
+    weight: 1
+    settings:
+      submit_text: 'Vælg ikon'
+      auto_select: false
+      view: itk_media_browser
+      view_display: entity_browser_3
+  81d6533a-5ddc-40e9-b2ef-6ed8dfb46b89:
+    id: entity_form
+    uuid: 81d6533a-5ddc-40e9-b2ef-6ed8dfb46b89
+    label: 'Upload new icon'
+    weight: 3
+    settings:
+      submit_text: 'Upload new icon to media library'
+      entity_type: media
+      bundle: icon
+      form_mode: default

--- a/config/sync/field.field.media.icon.field_itk_media_image_upload.yml
+++ b/config/sync/field.field.media.icon.field_itk_media_image_upload.yml
@@ -1,0 +1,38 @@
+uuid: 54587d77-6a0b-4278-a4b5-f0cca84dfae8
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_itk_media_image_upload
+    - media.type.icon
+  module:
+    - image
+id: media.icon.field_itk_media_image_upload
+field_name: field_itk_media_image_upload
+entity_type: media
+bundle: icon
+label: Image
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: svg
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/config/sync/field.field.node.landing_page.field_show_page_title.yml
+++ b/config/sync/field.field.node.landing_page.field_show_page_title.yml
@@ -1,0 +1,23 @@
+uuid: 9a381a83-d923-4782-9b9f-ffa332cf0ccd
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_show_page_title
+    - node.type.landing_page
+id: node.landing_page.field_show_page_title
+field_name: field_show_page_title
+entity_type: node
+bundle: landing_page
+label: 'Show page title'
+description: 'Toggle to either show or hide the title of the page.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.node.public_meeting.field_registration_deadline.yml
+++ b/config/sync/field.field.node.public_meeting.field_registration_deadline.yml
@@ -15,10 +15,7 @@ label: Tilmeldingsfrist
 description: ''
 required: false
 translatable: false
-default_value:
-  -
-    default_date_type: now
-    default_date: now
+default_value: {  }
 default_value_callback: ''
 settings: {  }
 field_type: datetime

--- a/config/sync/field.field.paragraph.content_list.field_content_list.yml
+++ b/config/sync/field.field.paragraph.content_list.field_content_list.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - field.storage.paragraph.field_content_list
     - paragraphs.paragraphs_type.content_list
-    - views.view.all_hearings
   module:
     - viewsreference
 id: paragraph.content_list.field_content_list
@@ -16,16 +15,7 @@ label: Indholdsliste
 description: ''
 required: false
 translatable: false
-default_value:
-  -
-    target_uuid: da3c6d29-0069-474d-ac19-126a479bf56c
-    display_id: default
-    data: null
-    options:
-      title: 0
-      argument: ''
-    argument: null
-    title: 0
+default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:view'
@@ -34,35 +24,14 @@ settings:
     auto_create: false
   plugin_types:
     default: default
-    page: '0'
-    autocompletion_callback: '0'
-    entity_reference: '0'
-    block: '0'
-    rest_export: '0'
-    entity_browser: '0'
-    data_export: '0'
   preselect_views:
     all_citizen_proposals: all_citizen_proposals
     all_hearings: all_hearings
     all_meetings: all_meetings
     all_projects: all_projects
-    advancedqueue_jobs: '0'
-    authmap: '0'
-    autocompletion_callbacks_nodes: '0'
-    autocompletion_callbacks_words: '0'
-    block_content: '0'
-    content: '0'
-    files: '0'
-    form_list_active_projects: '0'
-    hearings_related_to_project: '0'
-    heyloyalty_feed: '0'
-    itk_media: '0'
-    itk_media_browser: '0'
-    media: '0'
-    nearest_hearings: '0'
-    redirect: '0'
-    timeline_related_items: '0'
-    user_admin_people: '0'
-    watchdog: '0'
+    duplicate_of_alle_projekter: duplicate_of_alle_projekter
+    seneste_begivenheder: seneste_begivenheder
+    seneste_borgerforslag: seneste_borgerforslag
+    seneste_hoeringer: seneste_hoeringer
   enabled_settings: {  }
 field_type: viewsreference

--- a/config/sync/field.field.paragraph.link.field_decorative_arrow.yml
+++ b/config/sync/field.field.paragraph.link.field_decorative_arrow.yml
@@ -1,0 +1,21 @@
+uuid: a848c8e9-fd82-4814-b4d1-3607c738ffa0
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_decorative_arrow
+    - paragraphs.paragraphs_type.link
+id: paragraph.link.field_decorative_arrow
+field_name: field_decorative_arrow
+entity_type: paragraph
+bundle: link
+label: 'Decorative arrow'
+description: 'Whether to show a decorative arrow or not.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.paragraph.link.field_icon.yml
+++ b/config/sync/field.field.paragraph.link.field_icon.yml
@@ -1,0 +1,29 @@
+uuid: 67fe43c3-1236-4e06-8364-a2d1ae7e933c
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_icon
+    - media.type.icon
+    - paragraphs.paragraphs_type.link
+id: paragraph.link.field_icon
+field_name: field_icon
+entity_type: paragraph
+bundle: link
+label: Icon
+description: 'Select an icon'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      icon: icon
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.paragraph.link.field_link.yml
+++ b/config/sync/field.field.paragraph.link.field_link.yml
@@ -1,0 +1,45 @@
+uuid: 1031b9f7-55ea-4649-adef-73f493aaec10
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_link
+    - node.type.citizen_proposal
+    - node.type.hearing
+    - node.type.landing_page
+    - node.type.page_map
+    - node.type.project
+    - node.type.project_main_page
+    - node.type.project_page
+    - node.type.public_meeting
+    - node.type.static_page
+    - paragraphs.paragraphs_type.link
+id: paragraph.link.field_link
+field_name: field_link
+entity_type: paragraph
+bundle: link
+label: Link
+description: 'Select the content to link to'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      public_meeting: public_meeting
+      citizen_proposal: citizen_proposal
+      hearing: hearing
+      page_map: page_map
+      landing_page: landing_page
+      project_main_page: project_main_page
+      project_page: project_page
+      project: project
+      static_page: static_page
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: public_meeting
+field_type: entity_reference

--- a/config/sync/field.field.paragraph.links_on_a_background_image.field_links_list.yml
+++ b/config/sync/field.field.paragraph.links_on_a_background_image.field_links_list.yml
@@ -1,23 +1,19 @@
-uuid: 98270e15-a484-4cff-bc43-040ab281052c
+uuid: 085d9852-81f2-4f4f-8d35-e261cfd10aef
 langcode: da
 status: true
 dependencies:
   config:
-    - field.storage.node.field_section
-    - node.type.landing_page
-    - paragraphs.paragraphs_type.content_block
-    - paragraphs.paragraphs_type.content_list
-    - paragraphs.paragraphs_type.introduction
+    - field.storage.paragraph.field_links_list
+    - paragraphs.paragraphs_type.link
     - paragraphs.paragraphs_type.links_on_a_background_image
-    - paragraphs.paragraphs_type.teaser_row
   module:
     - entity_reference_revisions
-id: node.landing_page.field_section
-field_name: field_section
-entity_type: node
-bundle: landing_page
-label: 'Indholds region'
-description: 'Vælg den type indhold du ønsker at indsætte'
+id: paragraph.links_on_a_background_image.field_links_list
+field_name: field_links_list
+entity_type: paragraph
+bundle: links_on_a_background_image
+label: 'Links list'
+description: 'A list of links. Possibility of showing an icon and/or a decorative arrow.'
 required: false
 translatable: false
 default_value: {  }
@@ -26,19 +22,15 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
-      introduction: introduction
-      content_block: content_block
-      content_list: content_list
-      teaser_row: teaser_row
-      links_on_a_background_image: links_on_a_background_image
+      link: link
     negate: 0
     target_bundles_drag_drop:
       content_block:
-        weight: 5
-        enabled: true
+        weight: 14
+        enabled: false
       content_list:
-        weight: 5
-        enabled: true
+        weight: 15
+        enabled: false
       files:
         weight: 16
         enabled: false
@@ -49,17 +41,20 @@ settings:
         weight: 18
         enabled: false
       introduction:
-        weight: 4
+        weight: 19
+        enabled: false
+      link:
+        weight: 15
         enabled: true
       links_on_a_background_image:
         weight: 20
-        enabled: true
+        enabled: false
       projekt_billede_galleri:
         weight: 21
         enabled: false
       teaser_row:
-        weight: 6
-        enabled: true
+        weight: 22
+        enabled: false
       text:
         weight: 23
         enabled: false

--- a/config/sync/field.field.paragraph.links_on_a_background_image.field_paragraph_image.yml
+++ b/config/sync/field.field.paragraph.links_on_a_background_image.field_paragraph_image.yml
@@ -1,0 +1,29 @@
+uuid: 9e01adc8-cdfc-4859-8c4e-48c94efd878d
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_paragraph_image
+    - media.type.image
+    - paragraphs.paragraphs_type.links_on_a_background_image
+id: paragraph.links_on_a_background_image.field_paragraph_image
+field_name: field_paragraph_image
+entity_type: paragraph
+bundle: links_on_a_background_image
+label: 'Background image'
+description: 'Choose the image to display in the background'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_show_page_title.yml
+++ b/config/sync/field.storage.node.field_show_page_title.yml
@@ -1,18 +1,17 @@
-uuid: 792fb9f5-f00e-4420-968a-e0228707907e
+uuid: cfdc6fe3-9683-48cc-ba92-a271898e6fb0
 langcode: da
 status: true
 dependencies:
   module:
-    - itk_pretix
     - node
-id: node.field_pretix_dates
-field_name: field_pretix_dates
+id: node.field_show_page_title
+field_name: field_show_page_title
 entity_type: node
-type: pretix_date
+type: boolean
 settings: {  }
-module: itk_pretix
+module: core
 locked: false
-cardinality: -1
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/sync/field.storage.paragraph.field_decorative_arrow.yml
+++ b/config/sync/field.storage.paragraph.field_decorative_arrow.yml
@@ -1,0 +1,18 @@
+uuid: bcea51a6-ec2e-4e34-8a0a-78e653f601fb
+langcode: da
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_decorative_arrow
+field_name: field_decorative_arrow
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_icon.yml
+++ b/config/sync/field.storage.paragraph.field_icon.yml
@@ -1,0 +1,20 @@
+uuid: 38e0f5a3-36ef-427f-b163-b91ebbfc6eae
+langcode: da
+status: true
+dependencies:
+  module:
+    - media
+    - paragraphs
+id: paragraph.field_icon
+field_name: field_icon
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_link.yml
+++ b/config/sync/field.storage.paragraph.field_link.yml
@@ -1,0 +1,20 @@
+uuid: 46c51aa7-c0a0-4d82-82fb-05af2ea20519
+langcode: da
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_link
+field_name: field_link
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_links_list.yml
+++ b/config/sync/field.storage.paragraph.field_links_list.yml
@@ -1,0 +1,20 @@
+uuid: 5f4c4dc8-f6a4-4d7c-bbf6-2b87dd9db50f
+langcode: da
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_links_list
+field_name: field_links_list
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/image.style.vector_image.yml
+++ b/config/sync/image.style.vector_image.yml
@@ -1,0 +1,7 @@
+uuid: 47ce1871-88c6-4eb5-a706-630f44c275fb
+langcode: da
+status: true
+dependencies: {  }
+name: vector_image
+label: 'Vector image'
+effects: {  }

--- a/config/sync/language.content_settings.media.icon.yml
+++ b/config/sync/language.content_settings.media.icon.yml
@@ -1,0 +1,11 @@
+uuid: 134afb1e-2e66-40bf-a290-7a178638a34c
+langcode: da
+status: true
+dependencies:
+  config:
+    - media.type.icon
+id: media.icon
+target_entity_type_id: media
+target_bundle: icon
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/media.type.icon.yml
+++ b/config/sync/media.type.icon.yml
@@ -1,0 +1,18 @@
+uuid: 5183f0d0-d703-4d99-a504-1f2999362d22
+langcode: da
+status: true
+dependencies:
+  module:
+    - crop
+third_party_settings:
+  crop:
+    image_field: _none
+id: icon
+label: Icon
+description: 'Vector images used to display icons'
+source: image
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  source_field: field_itk_media_image_upload
+field_map: {  }

--- a/config/sync/paragraphs.paragraphs_type.link.yml
+++ b/config/sync/paragraphs.paragraphs_type.link.yml
@@ -1,0 +1,10 @@
+uuid: 6f937814-e772-4d7f-b23e-741c15602735
+langcode: da
+status: true
+dependencies: {  }
+id: link
+label: Link
+icon_uuid: null
+icon_default: null
+description: 'Link with possibility of showing an icon and/or a decorative arrow.'
+behavior_plugins: {  }

--- a/config/sync/paragraphs.paragraphs_type.links_on_a_background_image.yml
+++ b/config/sync/paragraphs.paragraphs_type.links_on_a_background_image.yml
@@ -1,0 +1,10 @@
+uuid: fac25dca-d944-4147-baf2-5d9c11d0ec58
+langcode: da
+status: true
+dependencies: {  }
+id: links_on_a_background_image
+label: 'Links on a background image'
+icon_uuid: null
+icon_default: null
+description: 'Commonly used in the top of a page, to show a collection of links.'
+behavior_plugins: {  }

--- a/config/sync/views.view.itk_media_browser.yml
+++ b/config/sync/views.view.itk_media_browser.yml
@@ -6,12 +6,13 @@ dependencies:
     - field.storage.media.field_itk_media_tag
     - image.style.thumbnail
     - media.type.document
+    - media.type.icon
     - media.type.image
     - taxonomy.vocabulary.media_library
   module:
     - entity_browser
-    - image
     - media
+    - svg_image
     - taxonomy
     - user
 _core:
@@ -300,7 +301,7 @@ display:
         type: basic
         options:
           submit_button: Apply
-          reset_button: false
+          reset_button: true
           reset_button_label: 'Nulstil søgning'
           exposed_sorts_label: 'Sort by'
           expose_sort_order: false
@@ -524,7 +525,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - user.permissions
       tags:
         - 'config:field.storage.media.field_itk_media_tag'
@@ -652,7 +652,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - user.permissions
       tags:
         - 'config:field.storage.media.field_itk_media_tag'
@@ -1071,7 +1070,428 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
+        - user.permissions
+      tags:
+        - 'config:field.storage.media.field_itk_media_tag'
+  entity_browser_3:
+    id: entity_browser_3
+    display_title: 'Icon browser'
+    display_plugin: entity_browser
+    position: 1
+    display_options:
+      fields:
+        entity_browser_select:
+          id: entity_browser_select
+          table: media
+          field: entity_browser_select
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          plugin_id: entity_browser_select
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        thumbnail__target_id:
+          id: thumbnail__target_id
+          table: media_field_data
+          field: thumbnail__target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: thumbnail
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image
+          settings:
+            image_link: ''
+            image_style: thumbnail
+            image_loading:
+              attribute: lazy
+            svg_attributes:
+              width: null
+              height: null
+            svg_render_as_image: true
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        name_1:
+          id: name_1
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: name
+          plugin_id: field
+          label: Navn
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_itk_media_tag:
+          id: field_itk_media_tag
+          table: media__field_itk_media_tag
+          field: field_itk_media_tag
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Tag
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        status:
+          id: status
+          table: media_field_data
+          field: status
+          entity_type: media
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        combine:
+          id: combine
+          table: views
+          field: combine
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: combine
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: combine_op
+            label: 'Search for images'
+            description: ''
+            use_operator: false
+            operator: combine_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: combine
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              editor: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          fields:
+            name_1: name_1
+        bundle:
+          id: bundle
+          table: media_field_data
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: bundle
+          plugin_id: bundle
+          operator: in
+          value:
+            icon: icon
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_itk_media_tag_target_id:
+          id: field_itk_media_tag_target_id
+          table: media__field_itk_media_tag
+          field: field_itk_media_tag_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_itk_media_tag_target_id_op
+            label: Tag
+            description: ''
+            use_operator: false
+            operator: field_itk_media_tag_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_itk_media_tag_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              editor: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: media_library
+          type: select
+          hierarchy: true
+          limit: true
+          error_message: true
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      defaults:
+        fields: false
+        filters: false
+        filter_groups: false
+      display_description: ''
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
         - user.permissions
       tags:
         - 'config:field.storage.media.field_itk_media_tag'
@@ -1090,7 +1510,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - user.permissions
       tags:
         - 'config:field.storage.media.field_itk_media_tag'

--- a/config/sync/views.view.seneste_begivenheder.yml
+++ b/config/sync/views.view.seneste_begivenheder.yml
@@ -1,0 +1,292 @@
+uuid: d27f3fd3-ab61-4ebc-9db5-27d2654e901d
+langcode: da
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.public_meeting
+  module:
+    - better_exposed_filters
+    - datetime
+    - node
+    - user
+id: seneste_begivenheder
+label: 'Seneste begivenheder'
+module: views
+description: 'En liste af alle begivenheder'
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Master
+    display_plugin: default
+    position: 0
+    display_options:
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 3
+      exposed_form:
+        type: bef
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Ønsket rækkefølge?'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+          input_required: false
+          text_input_required: 'Select any filter and click on Apply to see results'
+          text_input_required_format: filtered_html
+          bef:
+            general:
+              autosubmit: true
+              autosubmit_exclude_textfield: true
+              autosubmit_textfield_delay: 500
+              autosubmit_hide: true
+              input_required: false
+              allow_secondary: false
+              secondary_label: 'Advanced options'
+              secondary_open: false
+              text_input_required: 'Select any filter and click on Apply to see results'
+              text_input_required_format: basic_html
+            sort:
+              plugin_id: default
+              advanced:
+                combine: true
+                combine_rewrite: "Svarfrist Asc|Først kommende\r\nSvarfrist Desc|Sidst kommende"
+                reset: false
+                reset_label: ''
+                collapsible: false
+                collapsible_label: 'Sort options'
+                is_secondary: false
+                hide_label: true
+            filter:
+              field_area_target_id:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: "- Any -|Område\r\n- Enhver -|Vis alle områder"
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                  hide_label: true
+              field_content_state_value:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: "- Enhver -|Alle\r\nAfsluttet|Afsluttede\r\nKommende|Aktive"
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                  hide_label: true
+              field_type_target_id:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: "- Any -|Alle typer\r\n- Enhver -|Vælg type"
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                  hide_label: true
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: '<!-- This text is added to prevent the the view AND filters from being hidden if the view is empty (cf. https://www.drupal.org/project/viewsreference/issues/3399878) -->'
+          tokenize: false
+      sorts:
+        field_last_meeting_time_value:
+          id: field_last_meeting_time_value
+          table: node__field_last_meeting_time
+          field: field_last_meeting_time_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
+          order: DESC
+          expose:
+            label: Svarfrist
+            field_identifier: field_last_meeting_time_value
+          exposed: false
+          granularity: second
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: title
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            public_meeting: public_meeting
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      use_ajax: false
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/config/sync/views.view.seneste_borgerforslag.yml
+++ b/config/sync/views.view.seneste_borgerforslag.yml
@@ -1,0 +1,271 @@
+uuid: 0e4a1d82-6249-4d08-b727-6b6574150296
+langcode: da
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.citizen_proposal
+  module:
+    - better_exposed_filters
+    - datetime
+    - node
+    - user
+id: seneste_borgerforslag
+label: 'Seneste borgerforslag'
+module: views
+description: 'En liste af alle høringer'
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Master
+    display_plugin: default
+    position: 0
+    display_options:
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 3
+      exposed_form:
+        type: bef
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: Sortér
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+          input_required: false
+          text_input_required: 'Select any filter and click on Apply to see results'
+          text_input_required_format: filtered_html
+          bef:
+            general:
+              autosubmit: true
+              autosubmit_exclude_textfield: true
+              autosubmit_textfield_delay: 500
+              autosubmit_hide: true
+              input_required: false
+              allow_secondary: false
+              secondary_label: 'Advanced options'
+              secondary_open: false
+              text_input_required: 'Select any filter and click on Apply to see results'
+              text_input_required_format: basic_html
+              reset_button_always_show: false
+            sort:
+              plugin_id: default
+              advanced:
+                combine: true
+                combine_rewrite: "Afstemning start Desc|Nyeste\r\nAfstemning start Asc|Ældste"
+                reset: false
+                reset_label: ''
+                collapsible: false
+                collapsible_label: 'Sort options'
+                is_secondary: false
+                hide_label: true
+            filter:
+              field_content_state_value:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: "- Any -|Alle\r\n- Enhver -|Alle\r\nAfsluttet|Afstemning afsluttet\r\nI gang|Afstemning aktiv\r\nKommende|"
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                  hide_label: true
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: '<!-- This text is added to prevent the the view AND filters from being hidden if the view is empty (cf. https://www.drupal.org/project/viewsreference/issues/3399878) -->'
+          tokenize: false
+      sorts:
+        field_vote_start_value:
+          id: field_vote_start_value
+          table: node__field_vote_start
+          field: field_vote_start_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
+          order: DESC
+          expose:
+            label: 'Afstemning start'
+            field_identifier: field_vote_start_value
+          exposed: false
+          granularity: second
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: title
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            citizen_proposal: citizen_proposal
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      use_ajax: false
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/config/sync/views.view.seneste_hoeringer.yml
+++ b/config/sync/views.view.seneste_hoeringer.yml
@@ -1,0 +1,292 @@
+uuid: b1239ca7-5bbb-44db-a6c3-d0d2317944af
+langcode: da
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.hearing
+  module:
+    - better_exposed_filters
+    - datetime
+    - node
+    - options
+    - user
+id: seneste_hoeringer
+label: 'Seneste høringer'
+module: views
+description: 'En liste af alle høringer'
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Master
+    display_plugin: default
+    position: 0
+    display_options:
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 3
+      exposed_form:
+        type: bef
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+          input_required: false
+          text_input_required: 'Select any filter and click on Apply to see results'
+          text_input_required_format: filtered_html
+          bef:
+            general:
+              autosubmit: true
+              autosubmit_exclude_textfield: true
+              autosubmit_textfield_delay: 500
+              autosubmit_hide: true
+              input_required: false
+              allow_secondary: false
+              secondary_label: 'Advanced options'
+              secondary_open: false
+              text_input_required: 'Select any filter and click on Apply to see results'
+              text_input_required_format: basic_html
+              reset_button_always_show: false
+            sort:
+              plugin_id: default
+              advanced:
+                combine: true
+                combine_rewrite: "Svarfrist Asc|Først kommende\r\nSvarfrist Desc|Sidst kommende"
+                reset: false
+                reset_label: ''
+                collapsible: false
+                collapsible_label: 'Sort options'
+                is_secondary: false
+                hide_label: true
+            filter:
+              field_area_target_id:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: "- Any -|Område\r\n- Enhver -|Vis alle områder"
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                  hide_label: true
+              field_content_state_value:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: "- Any -|Alle\r\n- Enhver -|Alle\r\nAfsluttet|Afsluttede\r\nI gang|Aktive"
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                  hide_label: true
+              field_type_target_id:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: "- Any -|Alle typer\r\n- Enhver -|Vælg type"
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                  hide_label: true
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: '<!-- This text is added to prevent the the view AND filters from being hidden if the view is empty (cf. https://www.drupal.org/project/viewsreference/issues/3399878) -->'
+          tokenize: false
+      sorts:
+        field_reply_deadline_value:
+          id: field_reply_deadline_value
+          table: node__field_reply_deadline
+          field: field_reply_deadline_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            hearing: hearing
+          group: 1
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        field_content_state_value:
+          id: field_content_state_value
+          table: node__field_content_state
+          field: field_content_state_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: list_field
+          operator: or
+          value:
+            upcoming: upcoming
+            active: active
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      use_ajax: false
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/config/sync/views.view.seneste_projekter.yml
+++ b/config/sync/views.view.seneste_projekter.yml
@@ -1,0 +1,253 @@
+uuid: c4b8835a-f2ec-4669-9305-c05381515714
+langcode: da
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.project_main_page
+  module:
+    - better_exposed_filters
+    - node
+    - user
+id: seneste_projekter
+label: 'Seneste projekter'
+module: views
+description: 'En liste af alle projekter'
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Master
+    display_plugin: default
+    position: 0
+    display_options:
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 3
+      exposed_form:
+        type: bef
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+          input_required: false
+          text_input_required: 'Vælg et filter og klik på Anvend for at se resultater'
+          text_input_required_format: filtered_html
+          bef:
+            general:
+              autosubmit: true
+              autosubmit_exclude_textfield: true
+              autosubmit_textfield_delay: 500
+              autosubmit_hide: true
+              input_required: false
+              allow_secondary: false
+              secondary_label: 'Avancerede indstillinger'
+              secondary_open: false
+              text_input_required: 'Vælg et filter og klik på Anvend for at se resultater'
+              text_input_required_format: basic_html
+              reset_button_always_show: false
+            filter:
+              field_area_target_id:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: "- Any -|Område\r\n- Enhver -|Vælg område"
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                  hide_label: true
+              field_project_category_target_id:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: "- Any -|Alle\r\n- Enhver -|Alle"
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                  hide_label: true
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: '<!-- This text is added to prevent the the view AND filters from being hidden if the view is empty (cf. https://www.drupal.org/project/viewsreference/issues/3399878) -->'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            project_main_page: project_main_page
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: default
+        options:
+          row_class: ''
+          default_row_class: false
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: ''
+      use_ajax: false
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/web/modules/custom/hoeringsportal_base_fixtures/src/Drush/Commands/FixturesCommand.php
+++ b/web/modules/custom/hoeringsportal_base_fixtures/src/Drush/Commands/FixturesCommand.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\hoeringsportal_base_fixtures\Drush\Commands;
+
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drush\Attributes as CLI;
+use Drush\Commands\AutowireTrait;
+use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\VarExporter\VarExporter;
+
+/**
+ * A Drush commandfile.
+ */
+final class FixturesCommand extends DrushCommands {
+
+  use AutowireTrait;
+
+  /**
+   * Constructs a FixturesCommand object.
+   */
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * Dump fixture.
+   */
+  #[CLI\Command(name: 'hoeringsportal_base_fixtures:dump-fixture')]
+  #[CLI\Argument(name: 'entityType', description: 'Entity type.')]
+  #[CLI\Argument(name: 'entityId', description: 'Entity ID.')]
+  #[CLI\Usage(name: 'hoeringsportal_base_fixtures:dump-fixture node 87', description: 'Dump fixture for node 87')]
+  #[CLI\Usage(name: 'hoeringsportal_base_fixtures:dump-fixture media 42', description: 'Dump fixture for media 42')]
+  #[CLI\Usage(name: 'hoeringsportal_base_fixtures:dump-fixture paragraph 7', description: 'Dump fixture for paragraph 7')]
+  public function dump(string $entityType, string $entityId, array $options = []) {
+    $entity = $this->entityTypeManager->getStorage($entityType)->load($entityId);
+    if (!$entity) {
+      throw new InvalidArgumentException(sprintf('Cannot find %s entity with id %s.', $entityType, $entityId));
+    }
+    if (!$entity instanceof ContentEntityBase) {
+      throw new InvalidArgumentException(sprintf('Entity must be an instance of %s.', ContentEntityBase::class));
+    }
+
+    $this->io()->warning(<<<'EOF'
+The code below is only a scaffolding and it may not work.
+
+Caveats: Only fields whose names start with `field_` are handled.
+EOF
+    );
+
+    $this->output()->writeln([
+      '``` php',
+      sprintf('%s::create(%s)', $entity::class, VarExporter::export($this->convertEntity($entity))),
+      '```',
+    ]);
+    $this->output()->writeln('');
+  }
+
+  /**
+   * Convert entity to array.
+   *
+   * @return array
+   *   An array suitable for passing to
+   *   Drupal\Core\Entity\EntityInterface::create().
+   */
+  private function convertEntity(ContentEntityBase $entity): array {
+    $data = [
+      'type' => $entity->bundle(),
+    ];
+
+    foreach ($entity->getFields(FALSE) as $field) {
+      if (str_starts_with($field->getName(), 'field_')) {
+        $value = $field->getValue();
+        // Unwrap singleton array value containing an array.
+        if (array_is_list($value) && 1 === count($value)) {
+          $item = reset($value);
+          if (is_array($item)) {
+            $value = $item;
+          }
+        }
+        if (is_array($value) && 1 === count($value) && isset($value['value'])) {
+          $value = $value['value'];
+        }
+        $data[$field->getName()] = $value;
+      }
+    }
+
+    return $data;
+  }
+
+}

--- a/web/themes/custom/hoeringsportal/assets/css/hoeringsportal.scss
+++ b/web/themes/custom/hoeringsportal/assets/css/hoeringsportal.scss
@@ -6,7 +6,8 @@
   "module/splash", "module/lead", "module/line-clamp", "module/page-teaser",
   "module/responsive-image-as-background", "module/social-sharing-buttons",
   "module/form", "module/image-gallery", "module/spinner", "module/signup",
-  "module/list", "module/pager", "module/paragraph-files", "module/info_box",
+  "module/list", "module/pager", "module/paragraph-background-image",
+  "module/paragraph-files", "module/paragraph-link", "module/info_box",
   "module/search", "module/search-page", "module/newsletter", "module/proposal",
   "module/animation", "module/header-v2",
   "../../node_modules/slick-carousel/slick/slick";

--- a/web/themes/custom/hoeringsportal/assets/css/module/_paragraph-background-image.scss
+++ b/web/themes/custom/hoeringsportal/assets/css/module/_paragraph-background-image.scss
@@ -1,0 +1,24 @@
+.paragraph-background-image {
+  height: 25%;
+  min-height: 150px;
+
+  @include media-breakpoint-up(md) {
+    height: 25%;
+    min-height: 400px;
+  }
+
+  img {
+    width: 100%;
+    height: auto;
+    object-fit: cover;
+    object-position: center;
+  }
+}
+
+.paragraph-links-list {
+  margin-top: -50px;
+
+  @include media-breakpoint-up(md) {
+    margin-top: -100px;
+  }
+}

--- a/web/themes/custom/hoeringsportal/assets/css/module/_paragraph-link.scss
+++ b/web/themes/custom/hoeringsportal/assets/css/module/_paragraph-link.scss
@@ -1,0 +1,17 @@
+.paragraph-link {
+  background-color: white;
+  transition: border-color 0.1s ease;
+  border: 1px solid white;
+  &:hover {
+    border: 1px solid $petroleum-light;
+    transition: border-color 0.3s ease;
+  }
+
+  .paragraph-link-icon {
+    svg {
+      text-align: center;
+      width: 1.25em;
+      fill: currentColor;
+    }
+  }
+}

--- a/web/themes/custom/hoeringsportal/templates/ds/ds-1col.html.twig
+++ b/web/themes/custom/hoeringsportal/templates/ds/ds-1col.html.twig
@@ -11,15 +11,14 @@
 #}
 {% set image_exists = field_media_image_single['#items'][0].value is not null %}
 {% set header_text = field_teaser['#items'][0].value|striptags %}
+{% set show_page_title = field_show_page_title[0]['#markup']|striptags %}
 
 <div class="group-header">
   {% if image_exists %}
     {{ include(directory ~ '/templates/components/hero.html.twig', {image: ds_content.field_media_image_single, title: node.title.value, teaser: header_text}) }}
-  {% else %}
+  {% elseif show_page_title == 1 %}
     {{ include(directory ~ '/templates/components/header.html.twig', {header: node.title.value, teaser: header_text}) }}
   {% endif %}
 </div>
 
-<div {{ attributes.addClass('projects') }}>
-  {{ ds_content|without('field_teaser', 'field_media_image_single') }}
-</div>
+{{ ds_content|without('field_teaser', 'field_media_image_single', 'field_show_page_title') }}

--- a/web/themes/custom/hoeringsportal/templates/field/field--paragraph--field-links-list--links-on-a-background-image.html.twig
+++ b/web/themes/custom/hoeringsportal/templates/field/field--paragraph--field-links-list--links-on-a-background-image.html.twig
@@ -1,0 +1,30 @@
+{#
+/**
+ * @file
+ * Theme override for field-links--links-on-a-background-image
+ *
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-3">
+  {% for item in items %}
+    <div class="col">
+      {{ item.content }}
+    </div>
+  {% endfor %}
+</div>

--- a/web/themes/custom/hoeringsportal/templates/media/media--icon.html.twig
+++ b/web/themes/custom/hoeringsportal/templates/media/media--icon.html.twig
@@ -1,0 +1,19 @@
+{#
+/**
+ * @file
+ * Theme override to display a icon media item.
+ *
+ * Available variables:
+ * - name: Name of the media.
+ * - content: Media content.
+ *
+ * @see template_preprocess_media()
+ *
+ * @ingroup themeable
+ */
+#}
+
+{% if content %}
+  {{ content }}
+
+{% endif %}

--- a/web/themes/custom/hoeringsportal/templates/paragraph/paragraph--link.html.twig
+++ b/web/themes/custom/hoeringsportal/templates/paragraph/paragraph--link.html.twig
@@ -1,0 +1,13 @@
+{# Paragraph for link with icon and arrow #}
+
+{% set show_decorative_arrow = content.field_decorative_arrow[0]['#markup']|striptags %}
+{% set link_title = content.field_link[0]['#title'] %}
+{% set link_url = content.field_link[0]['#url'] %}
+
+<a href="{{ link_url }}" class="paragraph-link d-flex gap-2 align-items-center text-decoration-none flex-grow-1 p-3 rounded-1">
+  <span class="paragraph-link-icon">{{ content.field_icon }}</span>
+  <span class="text-black fw-semibold">{{ link_title }}</span>
+  {% if show_decorative_arrow == 1 %}
+    <i class="fas fa-arrow-right ms-auto"></i>
+  {% endif %}
+</a>

--- a/web/themes/custom/hoeringsportal/templates/paragraph/paragraph--links-on-a-background-image.html.twig
+++ b/web/themes/custom/hoeringsportal/templates/paragraph/paragraph--links-on-a-background-image.html.twig
@@ -1,0 +1,17 @@
+{# Paragraph for hero/header on landing page #}
+
+<div class="paragraph-background-image position-relative overflow-hidden">
+  {% if paragraph.field_paragraph_image.entity %}
+    {% set media = paragraph.field_paragraph_image.entity %}
+    {% if media.field_itk_media_image_upload.entity %}
+      {% set image_url = file_url(media.field_itk_media_image_upload.entity.uri.value) %}
+      <img class="position-absolute z-0 top-0 start-0 object-fit-cover" src="{{ image_url }}" alt="{{ media.field_itk_media_image_upload.entity.alt }}">
+    {% endif %}
+  {% endif %}
+</div>
+<div class="mx-3 mx-md-0">
+  <div class="paragraph-links-list container z-1 position-relative bg-body-secondary shadow-lg rounded-1 p-3 mx-md-auto p-md-5 w-100 w-md-auto">
+    {{ content.field_links_list }}
+  </div>
+</div>
+{{ content|without('field_paragraph_image', 'field_links_list') }}


### PR DESCRIPTION
Adds a Drush helper command, `hoeringsportal_base_fixtures:dump-fixture`,  for generating fixtures.

> [!WARNING]  
> The generated code may not work at all …

```` shell
$ drush hoeringsportal_base_fixtures:dump-fixture node 87
 !
 ! [WARNING] The code below is only a scaffolding and it may not work.
 !
 !           Caveats: Only fields whose names start with `field_` are handled.
 !

``` php
Drupal\node\Entity\Node::create([
    'type' => 'landing_page',
    'field_media_image_single' => [
        'target_id' => '16',
    ],
    'field_section' => [
        [
            'target_id' => '21',
            'target_revision_id' => '21',
        ],
        [
            'target_id' => '26',
            'target_revision_id' => '26',
        ],
    ],
    'field_teaser' => 'Her har du mulighed for at gøre opmærksom på dine synspunkter om en konkret høringssag.'."\n"
        ."\n"
        .'VIGTIGT: Der kan gå længere tid inden høringssvar bliver vist på siden. Dit svar er modtaget, når du har fået en kvitteringsmail.',
])
```
````
