### PR TITLE
Added token to setup-task

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -52,6 +52,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: arduino/setup-task@v2
+        # https://github.com/arduino/setup-task/tree/56d0cc033e3cecc5f07a291fdd39f29388d21800?tab=readme-ov-file#repo-token
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - run: |
           docker network create frontend
           task compose -- up --detach
@@ -70,6 +74,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - run: task coding-standards:assets:check
       # Check for any changes (task …:check runs task …:apply)
       - run: git diff --exit-code
@@ -80,6 +87,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - run: task coding-standards:markdown:check
       # Check for any changes (task …:check runs task …:apply)
       - run: git diff --exit-code
@@ -90,6 +100,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - run: |
           docker network create frontend
           task compose -- up --detach
@@ -104,6 +117,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - run: |
           docker network create frontend
           task compose -- up --detach
@@ -118,6 +134,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - run: |
           docker network create frontend
           task compose -- up --detach

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [4.9.0] - 2025-03-25
 
+* [PR-484](https://github.com/itk-dev/hoeringsportal/pull/484)
+  Added token to `arduino/setup-task`
 * [PR-483](https://github.com/itk-dev/hoeringsportal/pull/483)
   Made exports consistent
 * [PR-482](https://github.com/itk-dev/hoeringsportal/pull/482)


### PR DESCRIPTION
Prevents

> Error: API rate limit exceeded for 20.161.78.130. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)

when using `arduino/setup-task` (cf.  <https://github.com/arduino/setup-task/tree/56d0cc033e3cecc5f07a291fdd39f29388d21800?tab=readme-ov-file#repo-token>).

