### PR TITLE
Fixed “Log off” URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.8.7] - 2025-04-04
+
+* [PR-488](https://github.com/itk-dev/hoeringsportal/pull/488)
+  Fixed “Log off” URL
+
 ## [4.8.6] - 2025-04-02
 
 * [PR-479](https://github.com/itk-dev/hoeringsportal/pull/479)

--- a/web/modules/custom/itk_admin_links/templates/itk-admin-links-block.html.twig
+++ b/web/modules/custom/itk_admin_links/templates/itk-admin-links-block.html.twig
@@ -14,7 +14,7 @@
       <li class="itk-admin-links--item">{{ edit_link }}</li>
     {% endif %}
     <li class="itk-admin-links--item">
-      {{ drupal_link('Log off'|t, 'user.logout') }}
+      {{ drupal_link('Log off'|t, path('user.logout')) }}
     </li>
   </ul>
 </div>


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/TimeTable/TimeTable?showTicketModal=4223#/tickets/showTicket/4223

#### Description

Release 4.8.7: Fixes “Log off” URL.
