### PR TITLE
5209: Cleaned up public meeting summary view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-537](https://github.com/itk-dev/deltag.aarhus.dk/pull/537)
+  5209: Cleaned up public meeting summary view
+
 ## [4.11.0] - 2025-07-01
 
 * [PR-533](https://github.com/itk-dev/deltag.aarhus.dk/pull/533)

--- a/web/modules/custom/hoeringsportal_public_meeting/src/Helper/PublicMeetingHelper.php
+++ b/web/modules/custom/hoeringsportal_public_meeting/src/Helper/PublicMeetingHelper.php
@@ -381,7 +381,7 @@ class PublicMeetingHelper {
    * @return \Drupal\itk_pretix\Plugin\Field\FieldType\PretixDate[]|iterable|null
    *   The pretix dates if any.
    */
-  private function getPretixDates(NodeInterface $node): ?iterable {
+  public function getPretixDates(NodeInterface $node): ?iterable {
     if (!$this->isPublicMeeting($node) || !$this->hasPretixSignUp($node)) {
       return NULL;
     }

--- a/web/modules/custom/hoeringsportal_public_meeting/templates/hoeringsportal-public-meeting-summary.html.twig
+++ b/web/modules/custom/hoeringsportal_public_meeting/templates/hoeringsportal-public-meeting-summary.html.twig
@@ -101,5 +101,7 @@
   {% endif %}
 {% endif %}
 
-<h3 class="mt-3">{{ 'This event has multiple dates'|t }}</h3>
-<a href="#pretix_signup_list" class="btn btn-sm bg-primary text-white rounded py-1 px-3 mb-3">{{ 'View the list'|t }}</a>
+{% if public_meeting_helper.hasPretixSignUp(node) and public_meeting_helper.getPretixDates(node)|length > 1 %}
+  <h3 class="mt-3">{{ 'This event has multiple dates'|t }}</h3>
+  <a href="#pretix_signup_list" class="btn btn-sm bg-primary text-white rounded py-1 px-3 mb-3">{{ 'View the list'|t }}</a>
+{% endif %}

--- a/web/themes/custom/hoeringsportal/templates/field/field--dynamic-block-field--node-public-meeting-summary.html.twig
+++ b/web/themes/custom/hoeringsportal/templates/field/field--dynamic-block-field--node-public-meeting-summary.html.twig
@@ -36,11 +36,6 @@
  * @see template_preprocess_field()
  */
 #}
-{% set node = element['#object'] %}
-{% set meeting_cancelled = public_meeting_helper.isCancelled(node) %}
-{% set meeting_has_been_held = public_meeting_helper.hasBeenHeld(node) %}
-{% set registration_deadline_passed = public_meeting_helper.isDeadlinePassed(node) %}
-
 {% if label_hidden %}
   {% if multiple %}
     {% for item in items %}
@@ -68,15 +63,22 @@
   {% endif %}
 {% endif %}
 
-{% if meeting_cancelled %}
-  <div class="pretix-alert meeting-has-been-cancelled my-3">{{ 'Meeting has been cancelled'|t }}</div>
-{% elseif meeting_has_been_held %}
-  <div class="pretix-alert meeting-has-been-held my-3">{{ 'Meeting has already been held'|t }}</div>
-{% else %}
-  {% if registration_deadline_passed %}
-    {# @TODO: Design: styling of "alert" #}
-    <div class="pretix-alert pretix-alert-registration-deadline-passed my-3">{{ 'Registration deadline passed'|t }}</div>
+{% set node = element['#object'] %}
+{# pretix info is rendered in hoeringsportal-public-meeting-summary.html.twig #}
+{% if not public_meeting_helper.hasPretixSignUp(node) %}
+  {% set meeting_cancelled = public_meeting_helper.isCancelled(node) %}
+  {% set meeting_has_been_held = public_meeting_helper.hasBeenHeld(node) %}
+  {% set registration_deadline_passed = public_meeting_helper.isDeadlinePassed(node) %}
+
+  {% if meeting_cancelled %}
+    <div class="pretix-alert meeting-has-been-cancelled my-3">{{ 'Meeting has been cancelled'|t }}</div>
+  {% elseif meeting_has_been_held %}
+    <div class="pretix-alert meeting-has-been-held my-3">{{ 'Meeting has already been held'|t }}</div>
   {% else %}
-    <a id="sign-up-shortcut" class="btn btn-primary btn-sm my-3" style="display: none">{{ 'Sign up for public meeting'|t }}</a>
+    {% if registration_deadline_passed %}
+      <div class="pretix-alert pretix-alert-registration-deadline-passed my-3">{{ 'Registration deadline passed'|t }}</div>
+    {% else %}
+      <a id="sign-up-shortcut" class="btn btn-primary btn-sm my-3" style="display: none">{{ 'Sign up for public meeting'|t }}</a>
+    {% endif %}
   {% endif %}
 {% endif %}


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/_#/tickets/showTicket/5209

#### Description

Cleans up public meeting summary

* Hides “View the list” button if only one pretix date exists
* Removes duplicate meeting state info for pretix meetings

#### Screenshot of the result

Before:
<img width="2668" height="1578" alt="Screenshot 2025-08-20 at 16 55 41" src="https://github.com/user-attachments/assets/5af1c38d-6eb5-4618-9b3b-339da6ca966c" />

After:
<img width="2668" height="1578" alt="Screenshot 2025-08-20 at 16 56 12" src="https://github.com/user-attachments/assets/184e6125-ae3a-4f54-9db0-9d5a6db2dfb5" />

Before:
<img width="2668" height="1578" alt="Screenshot 2025-08-20 at 16 55 59" src="https://github.com/user-attachments/assets/c38fcb01-9e2f-472e-b91b-4ae1057543c3" />

After:
<img width="2668" height="1578" alt="Screenshot 2025-08-20 at 16 56 18" src="https://github.com/user-attachments/assets/437eed38-c655-450c-8408-059485322ae1" />

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
