### PR TITLE
Hide Department field on user if no departments are defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-547](https://github.com/itk-dev/deltag.aarhus.dk/pull/547)
+  Hid Department field on user if no departments are defined
+
 ## [4.13.0] - 2025-09-02
 
 * [PR-545](https://github.com/itk-dev/deltag.aarhus.dk/pull/545)

--- a/web/modules/custom/hoeringsportal_content_access/hoeringsportal_content_access.module
+++ b/web/modules/custom/hoeringsportal_content_access/hoeringsportal_content_access.module
@@ -28,6 +28,13 @@ function hoeringsportal_content_access_form_node_form_alter(array &$form, FormSt
 }
 
 /**
+ * Implements hook_form_alter().
+ */
+function hoeringsportal_content_access_form_alter(array &$form, FormStateInterface $form_state, string $form_id) {
+  return _hoeringsportal_content_access_get_helper()->formAlter($form, $form_state, $form_id);
+}
+
+/**
  * Implements template_preprocess_form_element().
  */
 function hoeringsportal_content_access_preprocess_form_element(&$variables) {

--- a/web/modules/custom/hoeringsportal_content_access/src/Helper.php
+++ b/web/modules/custom/hoeringsportal_content_access/src/Helper.php
@@ -154,6 +154,20 @@ final class Helper {
   }
 
   /**
+   * Implements hook_form_alter() for node_form.
+   */
+  public function formAlter(array &$form, FormStateInterface $formState, string $formId) {
+    if (in_array($formId, ['user_register_form', 'user_form'])) {
+      // Remove the department field if no departments are available.
+      if (isset($form[self::FIELD_DEPARTMENT]['widget']['#options'])
+        && empty($form[self::FIELD_DEPARTMENT]['widget']['#options'])
+      ) {
+        $form[self::FIELD_DEPARTMENT]['#access'] = FALSE;
+      }
+    }
+  }
+
+  /**
    * Implements template_preprocess_form_element().
    *
    * Hides departments the current user does not have access to.


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/_#/tickets/showTicket/5406 (cf. https://freescout.itkdev.dk/conversation/409?folder_id=33#thread-4997).

#### Description

Hides Department field on user forms when no departments are defined. Currently, when no departments are defined, a user cannot be edited (or created).

#### Screenshot of the result

Before:
<img width="1890" height="576" alt="Screenshot 2025-09-09 at 15 10 46" src="https://github.com/user-attachments/assets/580f8d20-a21b-4510-9ec8-e68ff3c253fe" />

After:
<img width="1890" height="576" alt="Screenshot 2025-09-09 at 15 11 05" src="https://github.com/user-attachments/assets/898ab0fa-9c5b-493e-8244-60c252e547e8" />

With one or more departments:
<img width="1890" height="576" alt="Screenshot 2025-09-09 at 15 11 57" src="https://github.com/user-attachments/assets/0b1abee2-99f0-4a52-a797-40e0d70d8deb" />

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
