### PR TITLE
Restored pretix development setup

### DIFF
--- a/.docker/pretix/etc/pretix.cfg
+++ b/.docker/pretix/etc/pretix.cfg
@@ -16,7 +16,7 @@ host=pretix_database
 
 [mail]
 from=admin@pretix.docker.localhost
-host=mailhog
+host=mail
 user=
 password=
 port=1025

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,7 +1,7 @@
 include:
   - docker-compose.oidc.yml
   - docker-compose.playwright.yml
-  #- docker-compose.pretix.yml
+  - docker-compose.pretix.yml
 
 services:
   phpfpm:

--- a/docker-compose.pretix.yml
+++ b/docker-compose.pretix.yml
@@ -3,9 +3,11 @@ networks:
     driver: bridge
     internal: false
 
+# https://docs.pretix.eu/self-hosting/installation/docker_smallscale/
+# https://github.com/ZPascal/pretix-docker-compose/tree/main
 services:
   pretix:
-    image: pretix/standalone:latest
+    image: pretix/standalone:stable
     profiles:
       - pretix
     networks:

--- a/documentation/localDevelopment.md
+++ b/documentation/localDevelopment.md
@@ -25,6 +25,10 @@ You can also set 'PROFILES` when running the `compose` task, e.g.
 PROFILES=pretix task compose -- up --detach
 ```
 
+You may have to increase the Memory Limit in Docker Desktop to be able to start
+pretix and it's internal services (cf.
+<https://github.com/celery/celery/issues/2966#issuecomment-567401386>).
+
 > [!TIP]
 > Run `git grep -A2 'profiles:' '*.y*ml'` to get a crude list of all profiles in the project.
 


### PR DESCRIPTION
Restores the pretix development setup and makes some minor tweaks. The changelog has not been updated.

> [!NOTE]
> You may have to increase the Memory Limit in Docker Desktop (e.g. to 32 GB, say) to be able to start pretix.

