### PR TITLE
Refactor timeline CSS to follow project conventions

### DIFF
--- a/web/themes/custom/hoeringsportal/assets/css/module/_timeline.scss
+++ b/web/themes/custom/hoeringsportal/assets/css/module/_timeline.scss
@@ -13,8 +13,8 @@
 // SCSS Variables & Mixins
 // =============================================================================
 
-// Layout variables
-$timeline-max-width: 900px;
+// Layout variables - using Bootstrap container widths for consistency
+$timeline-max-width: map-get($container-max-widths, lg); // 960px
 $timeline-card-gap: $spacer * 2; // 32px
 $timeline-line-width: 2px;
 $timeline-dot-size: 12px;
@@ -182,7 +182,7 @@ $timeline-accents: (
   font-size: $font-size-base;
   line-height: $line-height-base;
   color: var(--text-secondary);
-  max-width: 600px;
+  max-width: map-get($container-max-widths, sm); // 540px - text container
 }
 
 // =============================================================================
@@ -914,7 +914,7 @@ $carousel-padding-horizontal: ($spacer * 2.25); // 36px
 // Legend
 // =============================================================================
 .project-timeline-legend {
-  max-width: 500px;
+  max-width: map-get($container-max-widths, sm); // 540px - text container
   margin: $timeline-card-gap auto 0;
   padding: ($spacer * 1.25) $timeline-card-padding;
   background: var(--card-bg);


### PR DESCRIPTION
## Summary
- Replaced hardcoded hex colors with project color tokens from `_color-tokens.scss`
- Removed font-family override to inherit from theme (Arial stack)
- Created SCSS mixins for status/accent variant styles, reducing ~190 lines of repetitive code
- Used `@for` loop for z-index declarations (10 rules → 1 loop)
- Replaced magic numbers with SCSS variables (`$spacer`, `$timeline-card-gap`, etc.)

## Test plan
- [ ] Verify timeline renders correctly on project pages
- [ ] Check all status variants (completed, current, upcoming, note) display correctly
- [ ] Check accent variants (pink, blue) display correctly
- [ ] Test responsive behavior (mobile carousel, tablet, desktop)
- [ ] Verify mini-nav works correctly
- [ ] Check print styles

🤖 Generated with [Claude Code](https://claude.ai/code)