### PR TITLE
Add timeline fixtures with demo project

### DIFF
--- a/web/modules/custom/hoeringsportal_project/modules/hoeringsportal_project_fixtures/src/Fixture/ProjectMainPageFixture.php
+++ b/web/modules/custom/hoeringsportal_project/modules/hoeringsportal_project_fixtures/src/Fixture/ProjectMainPageFixture.php
@@ -5,10 +5,15 @@ namespace Drupal\hoeringsportal_project_fixtures\Fixture;
 use Drupal\content_fixtures\Fixture\AbstractFixture;
 use Drupal\content_fixtures\Fixture\DependentFixtureInterface;
 use Drupal\content_fixtures\Fixture\FixtureGroupInterface;
+use Drupal\hoeringsportal_base_fixtures\Fixture\DecisionFixture;
 use Drupal\hoeringsportal_base_fixtures\Fixture\MediaFixture;
 use Drupal\hoeringsportal_base_fixtures\Fixture\ParagraphFixture;
+use Drupal\hoeringsportal_base_fixtures\Fixture\PublicMeetingFixture;
 use Drupal\hoeringsportal_base_fixtures\Fixture\TermAreaFixture;
+use Drupal\hoeringsportal_dialogue_fixtures\Fixture\DialogueFixture;
+use Drupal\hoeringsportal_hearing_fixtures\Fixture\HearingFixture;
 use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\path_alias\Entity\PathAlias;
 use Drupal\pathauto\PathautoState;
@@ -113,6 +118,104 @@ BODY,
       ]);
 
     $entity->save();
+
+    // Create Timeline Demo Project with timeline enabled.
+    $timelineProject = Node::create([
+      'type' => 'project_main_page',
+    ])
+      ->setTitle('Timeline Demo Project')
+      ->set('field_project_category', [
+        $this->getReference('project_categories:Byudvikling'),
+      ])
+      ->set('field_short_description', 'A project demonstrating the timeline feature with various content types and notes.')
+      ->set('field_project_image', [
+        ['target_id' => $this->getReference('media:Medium1')->id()],
+      ])
+      ->set('field_area', [
+        $this->getReference('area:Hele kommunen'),
+      ])
+      ->set('field_show_timeline', TRUE);
+
+    // Add timeline note paragraphs.
+    $notes = [
+      [
+        'title' => 'Projektstart',
+        'subtitle' => 'Opstart af projekt',
+        'date' => (new \DateTimeImmutable('-6 months'))->format('Y-m-d'),
+        'note' => 'Projektet er officielt startet med en indledende undersøgelse af området.',
+      ],
+      [
+        'title' => 'Første fase afsluttet',
+        'subtitle' => 'Analyse gennemført',
+        'date' => (new \DateTimeImmutable('-3 months'))->format('Y-m-d'),
+        'note' => 'Den indledende analyse er nu gennemført og resultaterne er klar.',
+      ],
+      [
+        'title' => 'Planlagt borgermøde',
+        'subtitle' => 'Kommende aktivitet',
+        'date' => (new \DateTimeImmutable('+3 months'))->format('Y-m-d'),
+        'note' => 'Der planlægges et borgermøde for at præsentere de foreløbige resultater.',
+      ],
+      [
+        'title' => 'Forventet afslutning',
+        'subtitle' => 'Projektmål',
+        'date' => (new \DateTimeImmutable('+6 months'))->format('Y-m-d'),
+        'note' => 'Projektet forventes afsluttet med en endelig rapport og anbefalinger.',
+      ],
+    ];
+
+    foreach ($notes as $noteData) {
+      $paragraph = Paragraph::create([
+        'type' => 'timeline_note',
+      ])
+        ->set('field_title', $noteData['title'])
+        ->set('field_subtitle', $noteData['subtitle'])
+        ->set('field_date', $noteData['date'])
+        ->set('field_note', $noteData['note']);
+      $paragraph->save();
+
+      $timelineProject->field_timeline->appendItem([
+        'target_id' => $paragraph->id(),
+        'target_revision_id' => $paragraph->getRevisionId(),
+      ]);
+    }
+
+    $timelineProject->save();
+    $this->addReference('node:project_main_page:timeline_demo', $timelineProject);
+
+    // Update existing nodes to reference this project for timeline display.
+    $this->updateNodeProjectReference('node:hearing:Hearing1', $timelineProject, '-2 months');
+    $this->updateNodeProjectReference('node:dialogue:Test Dialogue - proposals full', $timelineProject);
+    $this->updateNodeProjectReference('node:decision:En vigtig afgørelse', $timelineProject, '-1 month');
+    $this->updateNodeProjectReference('public_meeting:fixture-1', $timelineProject);
+  }
+
+  /**
+   * Update a node to reference a project for timeline display.
+   *
+   * @param string $reference
+   *   The fixture reference key for the node.
+   * @param \Drupal\node\NodeInterface $project
+   *   The project node to reference.
+   * @param string|null $dateModifier
+   *   Optional date modifier string (e.g. '-2 months') to set the node's date.
+   */
+  private function updateNodeProjectReference(string $reference, NodeInterface $project, ?string $dateModifier = NULL): void {
+    $node = $this->getReference($reference);
+    $node->set('field_project_reference', ['target_id' => $project->id()]);
+    $node->set('field_hide_in_timeline', FALSE);
+
+    if ($dateModifier !== NULL) {
+      $date = (new \DateTimeImmutable($dateModifier))->format('Y-m-d\TH:i:s');
+      if ($node->hasField('field_start_date')) {
+        $node->set('field_start_date', $date);
+      }
+      if ($node->hasField('field_decision_date')) {
+        $node->set('field_decision_date', $date);
+      }
+    }
+
+    $node->save();
   }
 
   /**
@@ -126,6 +229,10 @@ BODY,
       ParagraphFixture::class,
       ProjectPageFixture::class,
       TermAreaFixture::class,
+      HearingFixture::class,
+      DialogueFixture::class,
+      DecisionFixture::class,
+      PublicMeetingFixture::class,
     ];
   }
 


### PR DESCRIPTION
Closes #607

## Summary
- Creates a "Timeline Demo Project" with timeline enabled
- Adds 4 timeline note paragraphs with varying dates (past and future)
- Links existing fixture nodes (hearing, dialogue, decision, public meeting) to the timeline project

## Test plan
- [ ] Run `task fixtures:load`
- [ ] Visit the Timeline Demo Project page
- [ ] Verify timeline displays all items correctly
- [ ] Toggle between horizontal and vertical views

🤖 Generated with [Claude Code](https://claude.com/claude-code)