### PR TITLE
Remove duplicate accordion.js import

### DIFF
--- a/web/themes/custom/hoeringsportal/assets/js/hoeringsportal.js
+++ b/web/themes/custom/hoeringsportal/assets/js/hoeringsportal.js
@@ -22,7 +22,6 @@ require("./modify-dialogue-proposal-comments.js");
 require("./animated-svg.js");
 require("./accordion.js");
 require("./timeline.js");
-require("./accordion.js");
 
 // Enable popovers.
 $(function () {


### PR DESCRIPTION
## Summary

- Remove duplicate `require("./accordion.js")` statement from `hoeringsportal.js` that was accidentally introduced in commit 720088de
- This prevents the accordion script from being loaded twice unnecessarily

## Test plan

- [ ] Verify accordion functionality still works correctly on pages using accordions
- [ ] Check browser network tab to confirm accordion.js is only loaded once

Fixes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)