### PR TITLE
Hide “Hide in timeline” from display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-639](https://github.com/itk-dev/deltag.aarhus.dk/pull/639)
+  Hid “Hide in timeline” from display
+
 ## [4.16.0] - 2026-03-09
 
 * [PR-635](https://github.com/itk-dev/deltag.aarhus.dk/pull/635)

--- a/config/sync/core.entity_view_display.node.hearing.default.yml
+++ b/config/sync/core.entity_view_display.node.hearing.default.yml
@@ -61,7 +61,6 @@ third_party_settings:
       header:
         - 'dynamic_block_field:node-hearing_warning'
         - node_title
-        - field_hide_in_timeline
       left:
         - field_teaser
         - field_description
@@ -150,16 +149,6 @@ content:
     third_party_settings: {  }
     weight: 3
     region: left
-  field_hide_in_timeline:
-    type: boolean
-    label: above
-    settings:
-      format: default
-      format_custom_false: ''
-      format_custom_true: ''
-    third_party_settings: {  }
-    weight: 21
-    region: header
   field_lokalplaner:
     type: hoeringsportal_data_localplan_default
     label: above
@@ -253,6 +242,7 @@ hidden:
   field_hearing_ticket_list: true
   field_hide_hearing_replies: true
   field_hide_hearing_replies_msg: true
+  field_hide_in_timeline: true
   field_map_display: true
   field_project_reference: true
   field_tags: true


### PR DESCRIPTION
#### Link to ticket

<https://leantime.itkdev.dk/_#/tickets/showTicket/7034>

#### Description

Hides a field that must not be shown in the frontend.

> [!NOTE]
> The change has been manually applied to the production system. 

#### Screenshot of the result

Before:

<img width="1006" height="289" alt="Screenshot 2026-03-20 at 13 22 12" src="https://github.com/user-attachments/assets/c60db01e-903f-442d-a045-7d9832c2b8a9" />

After:

<img width="1006" height="289" alt="Screenshot 2026-03-20 at 13 22 42" src="https://github.com/user-attachments/assets/2db4ee98-3b1e-4268-91b7-b19a92ae8a99" />
