### PR TITLE
Use string value when truncating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-640](https://github.com/itk-dev/deltag.aarhus.dk/pull/640)
+  Use string value when truncating
 * [PR-639](https://github.com/itk-dev/deltag.aarhus.dk/pull/639)
   Hid “Hide in timeline” from display
 

--- a/web/themes/custom/hoeringsportal/templates/content/node--decision--teaser.html.twig
+++ b/web/themes/custom/hoeringsportal/templates/content/node--decision--teaser.html.twig
@@ -3,7 +3,7 @@
 {% extends 'themes/custom/hoeringsportal/templates/components/base-card.html.twig' %}
 
 {% block card_content %}
-  {{ node.field_teaser.value|truncate(95, true, true) }}
+  {{ node.field_teaser.string|truncate(95, true, true) }}
   <span>{{ content.field_project_category }}</span>
   <span class="tags-one-line"><i class="{{ node_type_class }} fa-solid fa-tags"></i><span class="is-comma-separated">{{ content.field_area }}{{ content.field_type }}</span></span>
 {% endblock %}

--- a/web/themes/custom/hoeringsportal/templates/content/node--dialogue--teaser.html.twig
+++ b/web/themes/custom/hoeringsportal/templates/content/node--dialogue--teaser.html.twig
@@ -3,7 +3,7 @@
 {% extends 'themes/custom/hoeringsportal/templates/components/base-card.html.twig' %}
 
 {% block card_content %}
-  {{ node.field_teaser.value|truncate(95, true, true) }}
+  {{ node.field_teaser.string|truncate(95, true, true) }}
   <span>{{ content.field_project_category }}</span>
   <span class="tags-one-line"><i class="{{ node_type_class }} fa-solid fa-tags"></i><span class="is-comma-separated">{{ content.field_area }}{{ content.field_type }}</span></span>
 {% endblock %}

--- a/web/themes/custom/hoeringsportal/templates/content/node--hearing--teaser.html.twig
+++ b/web/themes/custom/hoeringsportal/templates/content/node--hearing--teaser.html.twig
@@ -35,7 +35,7 @@
 
 {# Show teaser description #}
 {% block card_content %}
-  {{ content.field_teaser[0]['#context'].value|truncate(95, true, true) }}
+  {{ node.field_teaser.string|truncate(95, true, true) }}
 {% endblock %}
 
 {# Collect data for information lines on card #}

--- a/web/themes/custom/hoeringsportal/templates/content/node--project-main-page--teaser.html.twig
+++ b/web/themes/custom/hoeringsportal/templates/content/node--project-main-page--teaser.html.twig
@@ -3,7 +3,7 @@
 {% extends 'themes/custom/hoeringsportal/templates/components/base-card.html.twig' %}
 
 {% block card_content %}
-  {{ node.field_short_description.value|truncate(95, true, true) }}
+  {{ node.field_short_description.string|truncate(95, true, true) }}
   <span>{{ content.field_project_category }}</span>
   <span class="tags-one-line"><i class="{{ node_type_class }} fa-solid fa-tags"></i><span class="is-comma-separated">{{ content.field_area }}{{ content.field_type }}</span></span>
 {% endblock %}


### PR DESCRIPTION
#### Link to ticket

<https://leantime.itkdev.dk/_#/tickets/showTicket/7042>

#### Description

If a project has an empty “Short description”, we get this error

```
The website encountered an unexpected error. Try again later.

TypeError: mb_strlen(): Argument #1 ($string) must be of type string, array given in mb_strlen() (line 310 of core/lib/Drupal/Component/Utility/Unicode.php).

Drupal\Component\Utility\Unicode::truncate() (Line: 62)
__TwigTemplate_45a2eb19437f776860ed86f207cfeb31->block_card_content() (Line: 432)
…
```

which is caused by passing an empty array (the fields `value`) to the `truncate` filter. Passing the `string` value of the field makes it work as expected.

A better solution might be to use [The line-clamp CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/line-clamp) to show only a few lines of the description.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
