### PR TITLE
7222: Used correct (and supported) fetch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-645](https://github.com/itk-dev/deltag.aarhus.dk/pull/645)
+  Use correct (and supported) fetch mode
+
 ## [4.16.3] - 2026-04-17
 
 * [PR-637](https://github.com/itk-dev/deltag.aarhus.dk/pull/644)

--- a/web/modules/custom/hoeringsportal_deskpro/src/Service/HearingHelper.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/Service/HearingHelper.php
@@ -743,7 +743,7 @@ class HearingHelper {
     $query->orderBy('aq.job_id');
     $result = $query->execute();
 
-    $jobs_definitions = $result->fetchAll(\PDO::FETCH_BOTH);
+    $jobs_definitions = $result->fetchAll(\PDO::FETCH_ASSOC);
     $jobs = [];
     foreach ($jobs_definitions as $job_definition) {
       $job_definition['id'] = $job_definition['job_id'];


### PR DESCRIPTION
#### Link to ticket

<https://leantime.itkdev.dk/_#/tickets/showTicket/7222>

#### Description

`\PDO::FETCH_BOTH` is not supported by Drupal 11 (cf. <https://www.drupal.org/project/drupal/issues/3345938>).

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

The failing checks are not related to the changes in this pull request.