### PR TITLE
7577: Updated handling of start and end times on timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-663](https://github.com/itk-dev/deltag.aarhus.dk/pull/663)
+  7577: Updated handling of start and end times on timeline
+
 * [PR-662](https://github.com/itk-dev/deltag.aarhus.dk/pull/662)
   7590: Fixed typo in date format ID reference
+
 * [PR-659](https://github.com/itk-dev/deltag.aarhus.dk/pull/659)
   Updated docker templates and updated yaml linting
-  
+
 * [PR-658](https://github.com/itk-dev/deltag.aarhus.dk/pull/658)
   * Replaced DAWA address autocomplete with Adressevaelger in hoeringsportal_forms and hoeringsportal_deskpro
   * Added Adressevaelger token configuration in admin settings

--- a/web/modules/custom/hoeringsportal_project/src/Hook/ProjectHooks.php
+++ b/web/modules/custom/hoeringsportal_project/src/Hook/ProjectHooks.php
@@ -24,6 +24,15 @@ use Drupal\paragraphs\ParagraphInterface;
 class ProjectHooks {
   use StringTranslationTrait;
 
+  public const string STATUS_COMPLETED = 'completed';
+  // Used for items whose start time and end time are on the same day and said
+  // day is today.
+  public const string STATUS_CURRENT = 'current';
+  // Used for items where "now" is between the item's start and end times.
+  public const string STATUS_IN_PROGRESS = 'in_progress';
+  public const string STATUS_NOTE = 'note';
+  public const string STATUS_UPCOMING = 'upcoming';
+
   /**
    * The logger channel.
    *
@@ -77,10 +86,11 @@ class ProjectHooks {
       usort($variables['timeline_items'], static fn(array $a, array $b): int => $a['date'] <=> $b['date']);
 
       $variables['legend_items'] = [
-        ['status' => 'completed', 'label' => $this->t('Finished')],
-        ['status' => 'current', 'label' => $this->t('In progress')],
-        ['status' => 'upcoming', 'label' => $this->t('Upcoming')],
-        ['status' => 'note', 'label' => $this->t('Note')],
+        ['status' => self::STATUS_COMPLETED, 'label' => $this->t('Finished')],
+        ['status' => self::STATUS_CURRENT, 'label' => $this->t('In progress')],
+        ['status' => self::STATUS_IN_PROGRESS, 'label' => $this->t('In progress')],
+        ['status' => self::STATUS_NOTE, 'label' => $this->t('Note')],
+        ['status' => self::STATUS_UPCOMING, 'label' => $this->t('Upcoming')],
       ];
     }
   }
@@ -228,20 +238,20 @@ class ProjectHooks {
    */
   private function addNodeAsTimelineItem(NodeInterface $node, DrupalDateTime $now): array {
     try {
-      $date = $this->determineDate($node);
-      if (!$date) {
+      [$startTime, $endTime] = $this->determineTimes($node);
+      if (!$startTime) {
         return [];
       }
       $image = $this->determineImage($node)?->getFileUri();
 
       return [
         'id' => $node->id(),
-        'date' => $date->format('Y-m-d'),
-        'month' => $date->format('F Y'),
+        'date' => $startTime->format('Y-m-d'),
+        'month' => $startTime->format('F Y'),
         'title' => $node->getTitle(),
         'subtitle' => $node->type->entity->label(),
         'description' => $node->field_teaser->value,
-        'status' => $this->determineStatus($node, $date, $now),
+        'status' => $this->determineStatus($node, $startTime, $endTime, $now),
         'image' => $image ? ImageStyle::load('responsive_medium_default')->buildUrl($image) : NULL,
         'link' => $this->urlGenerator->generateFromRoute('entity.node.canonical', ['node' => $node->id()]),
         'linkText' => $this->t('View <span>@type</span>', ['@type' => $node->type->entity->label()]),
@@ -280,7 +290,7 @@ class ProjectHooks {
         'title' => $paragraph->field_title->value,
         'subtitle' => $paragraph->field_subtitle->value,
         'description' => $paragraph->field_note->value,
-        'status' => $this->determineStatus($paragraph, $date, $now),
+        'status' => $this->determineStatus($paragraph, $date, $date, $now),
         'image' => $image ? ImageStyle::load('responsive_medium_default')->buildUrl($image) : NULL,
         'link' => $paragraph?->field_external_link?->uri ?? '',
         'linkText' => $this->t('View more'),
@@ -310,7 +320,7 @@ class ProjectHooks {
       'title' => $this->t('Project status'),
       'subtitle' => NULL,
       'description' => NULL,
-      'status' => 'current',
+      'status' => self::STATUS_CURRENT,
       'image' => NULL,
       'link' => NULL,
       'linkText' => NULL,
@@ -319,30 +329,56 @@ class ProjectHooks {
   }
 
   /**
-   * Determine date for timeline item.
+   * Determine start and end times for a timeline item.
    *
    * @param \Drupal\node\NodeInterface $node
    *   The node entity to extract the date from.
    *
-   * @return \Drupal\Core\Datetime\DrupalDateTime|null
-   *   The determined date or NULL if no date could be determined.
+   * @return array{
+   *   0: \Drupal\Core\Datetime\DrupalDateTime|null,
+   *   1: \Drupal\Core\Datetime\DrupalDateTime|null,
+   *   }
+   *   The determined start and end times if any.
    */
-  private function determineDate(NodeInterface $node): ?DrupalDateTime {
+  private function determineTimes(NodeInterface $node): array {
     try {
-      return match (TRUE) {
-        $node->hasField('field_decision_date') => new DrupalDateTime($node->field_decision_date->value),
-        $node->hasField('field_start_date') => new DrupalDateTime($node->field_start_date->value),
-        $node->hasField('field_last_meeting_time') => new DrupalDateTime($node->field_last_meeting_time->value),
-        'dialogue' === $node->getType() => new DrupalDateTime(strtotime($node->getCreatedTime())),
-        default => NULL,
-      };
+      switch ($node->getType()) {
+        case 'course':
+        case 'event':
+          return [
+            $node->get('field_first_meeting_time')->date,
+            $node->get('field_last_meeting_time')->date,
+          ];
+
+        case 'decision':
+          return [
+            $node->get('field_decision_date')->date,
+            $node->get('field_decision_date')->date,
+          ];
+
+        case 'dialogue':
+          return [
+            DrupalDateTime::createFromTimestamp($node->getCreatedTime()),
+            DrupalDateTime::createFromTimestamp($node->getCreatedTime()),
+          ];
+
+        case 'hearing':
+          return [
+            $node->get('field_start_date')->date,
+            $node->get('field_reply_deadline')->date,
+          ];
+
+        default:
+          throw new \RuntimeException(sprintf('Unhandled node type: %s',
+            $node->getType()));
+      }
     }
     catch (\Exception $e) {
       $this->logger->error('Error determining date for node @nid: @message', [
         '@nid' => $node->id(),
         '@message' => $e->getMessage(),
       ]);
-      return NULL;
+      return [NULL, NULL];
     }
   }
 
@@ -378,20 +414,27 @@ class ProjectHooks {
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The entity to determine status for.
-   * @param \Drupal\Core\Datetime\DrupalDateTime $date
-   *   The item date.
+   * @param \Drupal\Core\Datetime\DrupalDateTime $startTime
+   *   The start time.
+   * @param \Drupal\Core\Datetime\DrupalDateTime $endTime
+   *   The end time.
    * @param \Drupal\Core\Datetime\DrupalDateTime $now
    *   The current date.
    *
    * @return string
-   *   The status string (upcoming, completed, or note).
+   *   The status (one ot the STATUS_… constants).
    */
-  private function determineStatus(EntityInterface $entity, DrupalDateTime $date, DrupalDateTime $now): string {
+  private function determineStatus(EntityInterface $entity, DrupalDateTime $startTime, DrupalDateTime $endTime, DrupalDateTime $now): string {
+    $startDay = $startTime->format('Y-m-d');
+    $endDay = $endTime->format('Y-m-d');
+    $today = $now->format('Y-m-d');
+
     return match (TRUE) {
-      $date->format('Y-m-d') === $now->format('Y-m-d') => 'current',
-      $date > $now => 'upcoming',
-      $entity->getEntityTypeId() === 'node' => 'completed',
-      $entity->getEntityTypeId() === 'paragraph' => 'note',
+      $startDay === $endDay && $endDay === $today => self::STATUS_CURRENT,
+      $startTime <= $now && $now <= $endTime => self::STATUS_IN_PROGRESS,
+      $startTime > $now => self::STATUS_UPCOMING,
+      $entity->getEntityTypeId() === 'node' => self::STATUS_COMPLETED,
+      $entity->getEntityTypeId() === 'paragraph' => self::STATUS_NOTE,
       default => '',
     };
   }

--- a/web/themes/custom/hoeringsportal/templates/components/project-timeline-card.html.twig
+++ b/web/themes/custom/hoeringsportal/templates/components/project-timeline-card.html.twig
@@ -20,17 +20,19 @@
 #}
 
 {% set status_classes = {
-  completed: 'project-timeline-card--completed',
-  current: 'project-timeline-card--current',
-  upcoming: 'project-timeline-card--upcoming',
-  note: 'project-timeline-card--note',
+  (constant('Drupal\\hoeringsportal_project\\Hook\\ProjectHooks::STATUS_COMPLETED')): 'project-timeline-card--completed',
+  (constant('Drupal\\hoeringsportal_project\\Hook\\ProjectHooks::STATUS_CURRENT')): 'project-timeline-card--current',
+  (constant('Drupal\\hoeringsportal_project\\Hook\\ProjectHooks::STATUS_UPCOMING')): 'project-timeline-card--upcoming',
+  (constant('Drupal\\hoeringsportal_project\\Hook\\ProjectHooks::STATUS_NOTE')): 'project-timeline-card--note',
+  (constant('Drupal\\hoeringsportal_project\\Hook\\ProjectHooks::STATUS_IN_PROGRESS')): 'project-timeline-card--in-progress',
 } %}
 
 {% set status_labels = {
-  completed: 'now'|date('Y-m-d') == item.date ? 'Today'|t : '✓ Finished'|t,
-  current: 'Today'|t,
-  upcoming: 'Upcoming'|t,
-  note: 'Note'|t,
+  (constant('Drupal\\hoeringsportal_project\\Hook\\ProjectHooks::STATUS_COMPLETED')): 'now'|date('Y-m-d') == item.date ? 'Today'|t : '✓ Finished'|t,
+  (constant('Drupal\\hoeringsportal_project\\Hook\\ProjectHooks::STATUS_CURRENT')): 'Today'|t,
+  (constant('Drupal\\hoeringsportal_project\\Hook\\ProjectHooks::STATUS_UPCOMING')): 'Upcoming'|t,
+  (constant('Drupal\\hoeringsportal_project\\Hook\\ProjectHooks::STATUS_NOTE')): 'Note'|t,
+  (constant('Drupal\\hoeringsportal_project\\Hook\\ProjectHooks::STATUS_IN_PROGRESS')): 'In progress'|t,
 } %}
 
 {% set accent_class = item.accentColor ? 'project-timeline-card--accent-' ~ item.accentColor : '' %}

--- a/web/themes/custom/hoeringsportal/translations/hoeringsportal.da.po
+++ b/web/themes/custom/hoeringsportal/translations/hoeringsportal.da.po
@@ -3,8 +3,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2026-03-09 10:55+0100\n"
-"PO-Revision-Date: 2026-03-09 10:55+0100\n"
+"POT-Creation-Date: 2026-06-15 12:32+0200\n"
+"PO-Revision-Date: 2026-06-15 12:32+0200\n"
 "Last-Translator: NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
 "MIME-Version: 1.0\n"
@@ -264,6 +264,9 @@ msgstr "Jeg har læst betingelserne og giver mit samtykke"
 
 msgid "I represent"
 msgstr "Jeg udtaler mig som"
+
+msgid "In progress"
+msgstr "I gang"
 
 msgid "Information page"
 msgstr "Information"
@@ -714,4 +717,3 @@ msgstr "Tilmeldingsfrist overskredet"
 msgctxt "signup"
 msgid "Deadline:"
 msgstr "Tilmeldingsfrist:"
-


### PR DESCRIPTION
#### Link to ticket

<https://leantime.itkdev.dk/_#/tickets/showTicket/7577>

#### Description

Adds handling of both start and end times in timeline display.

#### Screenshot of the result

Before:

<img width="896" height="752" alt="Screen Shot 2026-06-15 at 12 28 08" src="https://github.com/user-attachments/assets/bc66cd40-640b-4e1c-8995-c93337d68742" />

After:

<img width="896" height="752" alt="Screen Shot 2026-06-15 at 12 28 57" src="https://github.com/user-attachments/assets/5d770ba4-e22d-44c3-b014-b9594b1942c8" />

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
