### PR TITLE
7740: Used blob ID as index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [4.17.0] - 2026-06-15
 
+* [PR-666](https://github.com/itk-dev/deltag.aarhus.dk/pull/666)
+  7740: Used blob ID as attachment index in Deskpro API call
+
 * [PR-663](https://github.com/itk-dev/deltag.aarhus.dk/pull/663)
   7577: Updated handling of start and end times on timeline
 

--- a/web/modules/custom/hoeringsportal_deskpro/src/Service/DeskproService.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/Service/DeskproService.php
@@ -393,7 +393,7 @@ class DeskproService {
     $attachments = [];
 
     foreach ($blobs as $blob) {
-      $attachments[] = [
+      $attachments[$blob['blob_id']] = [
         'blob_auth' => $blob['blob_auth'],
         'is_inline' => $inline,
       ];

--- a/web/modules/custom/hoeringsportal_deskpro/src/Service/HearingHelper.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/Service/HearingHelper.php
@@ -124,6 +124,15 @@ class HearingHelper {
   }
 
   /**
+   * Decide if replies have been deleted on a hearing.
+   */
+  public function haveHearingRepliesBeenDeleted(NodeInterface $node): bool {
+    $deleteDate = $this->getHearingRepliesDeletedOn($node);
+
+    return NULL !== $deleteDate && $deleteDate < new DrupalDateTime();
+  }
+
+  /**
    * Check if node is a hearing.
    */
   public function isHearing($node) {
@@ -339,6 +348,9 @@ class HearingHelper {
     if (!$this->isHearing($hearing)) {
       throw new \Exception('Invalid hearing: ' . $hearing->id());
     }
+    if ($this->haveHearingRepliesBeenDeleted($hearing)) {
+      throw new \Exception('Hearing replies have been deleted on hearing ' . $hearing->id());
+    }
 
     $deskproHearingId = $this->getHearingId($hearing);
 
@@ -445,8 +457,11 @@ class HearingHelper {
     try {
       $lockName = __METHOD__;
       if ($this->lock->acquire($lockName)) {
-        /** @var \Drupal\node\Entity\NodeInterface $hearing */
         [$hearing, $ticketId] = $this->validateTicketPayload($payload);
+
+        if ($this->haveHearingRepliesBeenDeleted($hearing)) {
+          throw new \Exception('Hearing replies have been deleted on hearing ' . $hearing->id());
+        }
 
         $ticket = $this->deskpro->getTicket($ticketId, [
           'expand' => ['fields', 'person', 'messages', 'attachments'],
@@ -533,8 +548,11 @@ class HearingHelper {
    * @param mixed $payload
    *   The payload.
    *
-   * @return array
-   *   The hearing node and ticket id ([NodeInterface, string]).
+   * @return array{
+   *   0: NodeInterface,
+   *   1: string
+   *   }
+   *   The hearing node and ticket id.
    *
    * @throws \RuntimeException
    */


### PR DESCRIPTION
#### Link to ticket

<https://leantime.itkdev.dk/#/tickets/showTicket/7740>

#### Description

Fixes an issue with/in Deskpro related to us not using the blob ID as attachment index (cf. <https://support.deskpro.com/en-US/guides/developers/deskpro-api/php-sdk-2/example-create-ticket>). It has worked for 8 years, but doesn't work anymore …

Furthermore prevents synchronizing replies (tickets) on hearings where the replies have been deleted.

