### PR TITLE
7805: Added display of owner name om proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [4.17.0] - 2026-06-15
 
+* [PR-667](https://github.com/itk-dev/deltag.aarhus.dk/pull/667)
+  7805: Added display of owner name om proposal
+
 * [PR-666](https://github.com/itk-dev/deltag.aarhus.dk/pull/666)
   7740: Used blob ID as attachment index in Deskpro API call
 

--- a/web/themes/custom/hoeringsportal/templates/content/node--dialogue-proposal--full.html.twig
+++ b/web/themes/custom/hoeringsportal/templates/content/node--dialogue-proposal--full.html.twig
@@ -51,6 +51,11 @@
         </div>
 
         <div class="node-metadata small">
+          {% set owner = anonymous_edit_helper.getContentOwner(node) %}
+          {% if owner and owner.name|default(false) %}
+            <div class="node-name">{{ owner.isCurrent ? 'You'|t : owner.name }}</div>
+          {% endif %}
+
           <div class="node-time">
             {{ node.changed.value|time_diff }}
             {% if node.changed.value > node.created.value %}


### PR DESCRIPTION
#### Link to ticket

<https://leantime.itkdev.dk/_#/tickets/showTicket/7805>

#### Description

Adds missing owner name display on proposals.

#### Screenshot of the result

Before:

<img width="875" height="353" alt="Screenshot 2026-06-29 at 09 46 33" src="https://github.com/user-attachments/assets/e7da701b-8ee8-4891-a41e-db56b7434410" />

After:

<img width="875" height="353" alt="Screenshot 2026-06-29 at 09 46 39" src="https://github.com/user-attachments/assets/290299fc-82d0-4999-b6c5-06d1dd86598a" />

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
