### PR TITLE
feat: dialog export functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.16.9] - 2026-07-01
+
 * [PR-668](https://github.com/itk-dev/deltag.aarhus.dk/pull/668)
   7833: Added Excel export of a dialogue with proposals and comments
 
@@ -754,6 +756,7 @@ Updated drupal core 8.6.16
 Initial release
 
 [Unreleased]: https://github.com/itk-dev/hoeringsportal/compare/4.16.8...HEAD
+[4.16.9]: https://github.com/itk-dev/hoeringsportal/compare/4.16.8...4.16.9
 [4.16.8]: https://github.com/itk-dev/hoeringsportal/compare/4.16.4...4.16.8
 [4.16.4]: https://github.com/itk-dev/hoeringsportal/compare/4.16.3...4.16.4
 [4.16.3]: https://github.com/itk-dev/hoeringsportal/compare/4.16.2...4.16.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-668](https://github.com/itk-dev/deltag.aarhus.dk/pull/668)
+  7833: Added Excel export of a dialogue with proposals and comments
+
 ## [4.16.8] - 2026-05-21
 
 * [PR-657](https://github.com/itk-dev/deltag.aarhus.dk/pull/657)

--- a/config/sync/views.view.dialogue_full_export.yml
+++ b/config/sync/views.view.dialogue_full_export.yml
@@ -203,7 +203,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'access content overview'
+          perm: 'administer citizen proposal'
       cache:
         type: tag
         options: {  }

--- a/config/sync/views.view.dialogue_full_export.yml
+++ b/config/sync/views.view.dialogue_full_export.yml
@@ -1,0 +1,441 @@
+uuid: 41faae4d-d31c-408e-abf2-9c9e966fb5b2
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.comment.field_comment
+    - field.storage.node.field_dialogue_proposal_descr
+    - flag.flag.support_comment
+    - flag.flag.support_proposal
+    - node.type.dialogue
+    - node.type.dialogue_proposal
+  module:
+    - comment
+    - flag
+    - node
+    - rest
+    - serialization
+    - user
+    - views_data_export
+    - xls_serialization
+id: dialogue_full_export
+label: 'Dialog – fuldt udtræk (forslag + kommentarer)'
+module: views
+description: 'Udtræk for én dialog: alle forslag og deres kommentarer med likes. Forslag uden kommentarer medtages med tomme kommentar-kolonner.'
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Dialog – fuldt udtræk'
+      fields:
+        dialog_id:
+          id: dialog_id
+          table: node_field_data
+          field: nid
+          relationship: field_dialogue
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: DialogID
+        dialog_titel:
+          id: dialog_titel
+          table: node_field_data
+          field: title
+          relationship: field_dialogue
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: DialogTitel
+          settings:
+            link_to_entity: false
+        dialog_dato:
+          id: dialog_dato
+          table: node_field_data
+          field: created
+          relationship: field_dialogue
+          entity_type: node
+          entity_field: created
+          plugin_id: field
+          label: DialogDato
+          type: timestamp
+          settings:
+            date_format: custom
+            custom_date_format: 'Y-m-d H:i:s'
+            timezone: ''
+            tooltip:
+              date_format: ''
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+        forslag_id:
+          id: forslag_id
+          table: node_field_data
+          field: nid
+          relationship: none
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: DialogForslagID
+        forslag_titel:
+          id: forslag_titel
+          table: node_field_data
+          field: title
+          relationship: none
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: DialogForslagTitel
+          settings:
+            link_to_entity: false
+        forslag_dato:
+          id: forslag_dato
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: field
+          label: DialogForslagDato
+          type: timestamp
+          settings:
+            date_format: custom
+            custom_date_format: 'Y-m-d H:i:s'
+            timezone: ''
+        forslag_indhold:
+          id: forslag_indhold
+          table: node__field_dialogue_proposal_descr
+          field: field_dialogue_proposal_descr
+          relationship: none
+          plugin_id: field
+          label: DialogForslagIndhold
+        forslag_likes:
+          id: forslag_likes
+          table: flag_counts
+          field: count
+          relationship: flag_proposal
+          plugin_id: numeric
+          label: DialogforslagLikes(count)
+          empty_zero: false
+        kommentar_id:
+          id: kommentar_id
+          table: comment_field_data
+          field: cid
+          relationship: field_comments_cid
+          entity_type: comment
+          entity_field: cid
+          plugin_id: field
+          label: DialogForslagKommentarID
+        kommentar_svar_til:
+          id: kommentar_svar_til
+          table: comment_field_data
+          field: cid
+          relationship: parent_comment
+          group_type: group
+          admin_label: ''
+          entity_type: comment
+          entity_field: cid
+          plugin_id: field
+          label: DialogForslagKommentarSvarTilID
+        kommentar_beskrivelse:
+          id: kommentar_beskrivelse
+          table: comment__field_comment
+          field: field_comment
+          relationship: field_comments_cid
+          plugin_id: field
+          label: DialogForslagKommentarBeskrivelse
+        kommentar_dato:
+          id: kommentar_dato
+          table: comment_field_data
+          field: created
+          relationship: field_comments_cid
+          entity_type: comment
+          entity_field: created
+          plugin_id: field
+          label: DialogForslagKommentarDato
+          type: timestamp
+          settings:
+            date_format: custom
+            custom_date_format: 'Y-m-d H:i:s'
+            timezone: ''
+            tooltip:
+              date_format: ''
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+        kommentar_likes:
+          id: kommentar_likes
+          table: flag_counts
+          field: count
+          relationship: flag_comment
+          plugin_id: numeric
+          label: DialogForslagKommentarLikes(count)
+          empty_zero: false
+      pager:
+        type: none
+        options:
+          offset: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Anvend
+          reset_button: false
+          reset_button_label: Nulstil
+          exposed_sorts_label: 'Sortér efter'
+          expose_sort_order: true
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+      access:
+        type: perm
+        options:
+          perm: 'access content overview'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        forslag_id:
+          id: forslag_id
+          table: node_field_data
+          field: nid
+          relationship: none
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+          order: ASC
+        kommentar_dato:
+          id: kommentar_dato
+          table: comment_field_data
+          field: created
+          relationship: field_comments_cid
+          entity_type: comment
+          entity_field: created
+          plugin_id: date
+          order: ASC
+      arguments:
+        field_dialogue_target_id:
+          id: field_dialogue_target_id
+          table: node__field_dialogue
+          field: field_dialogue_target_id
+          relationship: none
+          plugin_id: entity_target_id
+          default_action: 'not found'
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          summary_options: {  }
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:node'
+            fail: 'not found'
+          validate_options:
+            bundles:
+              dialogue: dialogue
+            access: false
+            operation: view
+            multiple: 0
+          break_phrase: false
+          not: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            dialogue_proposal: dialogue_proposal
+          group: 1
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+      row:
+        type: fields
+      relationships:
+        field_dialogue:
+          id: field_dialogue
+          table: node__field_dialogue
+          field: field_dialogue
+          relationship: none
+          admin_label: Dialog
+          plugin_id: standard
+          required: true
+        field_comments_cid:
+          id: field_comments_cid
+          table: node_field_data
+          field: field_comments_cid
+          relationship: none
+          admin_label: Kommentarer
+          plugin_id: standard
+          required: false
+        flag_proposal:
+          id: flag_proposal
+          table: node_field_data
+          field: flag_relationship
+          relationship: none
+          admin_label: 'Flag forslag'
+          entity_type: node
+          plugin_id: flag_relationship
+          required: false
+          flag: support_proposal
+          user_scope: any
+        flag_comment:
+          id: flag_comment
+          table: comment_field_data
+          field: flag_relationship
+          relationship: field_comments_cid
+          admin_label: 'Flag kommentar'
+          entity_type: comment
+          plugin_id: flag_relationship
+          required: false
+          flag: support_comment
+          user_scope: any
+        parent_comment:
+          id: parent_comment
+          table: comment_field_data
+          field: pid
+          relationship: field_comments_cid
+          group_type: group
+          admin_label: 'Svar til kommentar'
+          entity_type: comment
+          plugin_id: standard
+          required: false
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.comment.field_comment'
+        - 'config:field.storage.node.field_dialogue_proposal_descr'
+        - flag.flag.support_comment
+        - flag.flag.support_proposal
+  data_export_2:
+    id: data_export_2
+    display_title: 'Dataeksport (XLSX)'
+    display_plugin: data_export
+    position: 1
+    display_options:
+      pager:
+        type: none
+        options:
+          offset: 0
+      style:
+        type: data_export
+        options:
+          formats:
+            xlsx: xlsx
+      row:
+        type: data_field
+        options:
+          field_options:
+            dialog_id:
+              alias: DialogID
+              raw_output: false
+            dialog_titel:
+              alias: DialogTitel
+              raw_output: false
+            dialog_dato:
+              alias: DialogDato
+              raw_output: false
+            forslag_id:
+              alias: DialogForslagID
+              raw_output: false
+            forslag_titel:
+              alias: DialogForslagTitel
+              raw_output: false
+            forslag_dato:
+              alias: DialogForslagDato
+              raw_output: false
+            forslag_indhold:
+              alias: DialogForslagIndhold
+              raw_output: false
+            forslag_likes:
+              alias: DialogforslagLikes(count)
+              raw_output: false
+            kommentar_id:
+              alias: DialogForslagKommentarID
+              raw_output: false
+            kommentar_svar_til:
+              alias: DialogForslagKommentarSvarTilID
+              raw_output: false
+            kommentar_beskrivelse:
+              alias: DialogForslagKommentarBeskrivelse
+              raw_output: false
+            kommentar_dato:
+              alias: DialogForslagKommentarDato
+              raw_output: false
+            kommentar_likes:
+              alias: DialogForslagKommentarLikes(count)
+              raw_output: false
+      defaults:
+        pager: false
+        style: false
+        row: false
+      display_description: ''
+      display_extenders: {  }
+      path: admin/content/dialogue/full-export.xlsx
+      filename: 'deltag-dialog-fuldt-udtraek-[date:html_date].xlsx'
+      automatic_download: true
+      custom_redirect_path: false
+      redirect_to_display: none
+      include_query_params: true
+      store_in_public_file_directory: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - request_format
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.comment.field_comment'
+        - 'config:field.storage.node.field_dialogue_proposal_descr'
+        - flag.flag.support_comment
+        - flag.flag.support_proposal

--- a/web/modules/custom/hoeringsportal_dialogue/hoeringsportal_dialogue.links.task.yml
+++ b/web/modules/custom/hoeringsportal_dialogue/hoeringsportal_dialogue.links.task.yml
@@ -15,3 +15,9 @@ hoeringsportal_dialogue.admin_replies:
   weight: 1
   cache_tags:
     - comment_list
+
+hoeringsportal_dialogue.export_xlsx:
+  title: "Eksportér til Excel"
+  route_name: hoeringsportal_dialogue.export_xlsx
+  base_route: entity.node.canonical
+  weight: 50

--- a/web/modules/custom/hoeringsportal_dialogue/hoeringsportal_dialogue.routing.yml
+++ b/web/modules/custom/hoeringsportal_dialogue/hoeringsportal_dialogue.routing.yml
@@ -38,3 +38,12 @@ hoeringsportal_dialogue.map_view:
   requirements:
     _permission: "access content"
     node: \d+
+
+hoeringsportal_dialogue.export_xlsx:
+  path: "/node/{node}/dialogue-export"
+  defaults:
+    _controller: '\Drupal\hoeringsportal_dialogue\Controller\DialogueController::exportXlsx'
+    _title: "Eksportér til Excel"
+  requirements:
+    _custom_access: '\Drupal\hoeringsportal_dialogue\Controller\DialogueController::exportAccess'
+    node: \d+

--- a/web/modules/custom/hoeringsportal_dialogue/src/Controller/DialogueController.php
+++ b/web/modules/custom/hoeringsportal_dialogue/src/Controller/DialogueController.php
@@ -2,10 +2,13 @@
 
 namespace Drupal\hoeringsportal_dialogue\Controller;
 
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Drupal\Core\Extension\ThemeExtensionList;
 
 /**
@@ -145,6 +148,38 @@ class DialogueController extends ControllerBase {
       ],
       'features' => $proposalLocations,
     ];
+  }
+
+  /**
+   * Redirect to the XLSX export of a dialogue's proposals and comments.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   A dialogue node.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Redirect to the views data export endpoint for this dialogue.
+   */
+  public function exportXlsx(NodeInterface $node): RedirectResponse {
+    $url = Url::fromUri('internal:/admin/content/dialogue/full-export.xlsx/' . $node->id());
+
+    return new RedirectResponse($url->toString());
+  }
+
+  /**
+   * Access check for the dialogue export tab.
+   *
+   * The tab is only shown on dialogue nodes for users who may export content.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node from the route.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function exportAccess(NodeInterface $node): AccessResultInterface {
+    return AccessResult::allowedIfHasPermission($this->currentUser(), 'access content overview')
+      ->andIf(AccessResult::allowedIf('dialogue' === $node->bundle()))
+      ->addCacheableDependency($node);
   }
 
 }

--- a/web/modules/custom/hoeringsportal_dialogue/src/Controller/DialogueController.php
+++ b/web/modules/custom/hoeringsportal_dialogue/src/Controller/DialogueController.php
@@ -177,7 +177,7 @@ class DialogueController extends ControllerBase {
    *   The access result.
    */
   public function exportAccess(NodeInterface $node): AccessResultInterface {
-    return AccessResult::allowedIfHasPermission($this->currentUser(), 'access content overview')
+    return AccessResult::allowedIfHasPermission($this->currentUser(), 'administer citizen proposal')
       ->andIf(AccessResult::allowedIf('dialogue' === $node->bundle()))
       ->addCacheableDependency($node);
   }

--- a/web/sites/development.services.yml
+++ b/web/sites/development.services.yml
@@ -19,12 +19,12 @@ services:
     class: Drupal\Core\Cache\NullBackendFactory
   logger.channel.config_schema:
     parent: logger.channel_base
-    arguments: [ 'config_schema' ]
+    arguments: ["config_schema"]
   config.schema_checker:
     class: Drupal\Core\Config\Development\LenientConfigSchemaChecker
     arguments:
-      - '@config.typed'
-      - '@messenger'
-      - '@logger.channel.config_schema'
+      - "@config.typed"
+      - "@messenger"
+      - "@logger.channel.config_schema"
     tags:
       - { name: event_subscriber }


### PR DESCRIPTION
#### Link to ticket

[#7833](https://leantime.itkdev.dk/#/tickets/showTicket/7833)

#### Description

- Create a view for exporting a dialog including all related proposals with the following columns:

  DialogID
  DialogTitel
  DialogDato
  DialogForslagID
  DialogForslagTitel
  DialogForslagDato
  DialogForslagIndhold
  DialogforslagLikes(count)
  DialogForslagKommentarID
  DialogForslagKommentarBeskrivelse
  DialogForslagKommentarDato
  DialogForslagKommentarLikes(count)
  
  on the following endpoint: /node/{NID}/dialogue-export

- Create a button(tab) on the dialog edit page (e.g. node/{NID}/edit), called "Eksportér til Excel", calling the view export endpoint directly.

#### Screenshot of the result

<img width="2056" height="1329" alt="Screenshot 2026-06-30 at 14 30 50" src="https://github.com/user-attachments/assets/ee689703-94a9-41df-9f4d-813c0f9027d2" />

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
