### PR TITLE
Release 4.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.17.2] - 2026-08-13
+
+* [PR-679](https://github.com/itk-dev/deltag.aarhus.dk/pull/679)
+  * Fixed issue with files uploaded to Deskpro becoming temporary
+
 ## [4.17.1] - 2026-08-11
 
 * [PR-676](https://github.com/itk-dev/deltag.aarhus.dk/pull/676)
@@ -823,7 +828,8 @@ Updated drupal core 8.6.16
 
 Initial release
 
-[Unreleased]: https://github.com/itk-dev/hoeringsportal/compare/4.17.1...HEAD
+[Unreleased]: https://github.com/itk-dev/hoeringsportal/compare/4.17.2...HEAD
+[4.17.2]: https://github.com/itk-dev/hoeringsportal/compare/4.17.1...4.17.2
 [4.17.1]: https://github.com/itk-dev/hoeringsportal/compare/4.17.0...4.17.1
 [4.17.0]: https://github.com/itk-dev/hoeringsportal/compare/4.16.10...4.17.0
 [4.16.10]: https://github.com/itk-dev/hoeringsportal/compare/4.16.9...4.16.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* [PR-678](https://github.com/itk-dev/deltag.aarhus.dk/pull/678)
+  * Fixed bug project timeline element display
+
 ## [4.17.1] - 2026-08-11
 
 * [PR-676](https://github.com/itk-dev/deltag.aarhus.dk/pull/676)

--- a/web/modules/custom/hoeringsportal_deskpro/src/Form/HearingTicketAddForm.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/Form/HearingTicketAddForm.php
@@ -324,6 +324,7 @@ final class HearingTicketAddForm extends FormBase {
       \Drupal::logger('hoeringsportal_deskpro')->error('@message', [
         '@message' => $exception->getMessage(),
         '@values' => $form_state->getValues(),
+        'exception' => $exception,
       ]);
     }
   }

--- a/web/modules/custom/hoeringsportal_deskpro/src/Service/DeskproService.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/Service/DeskproService.php
@@ -404,6 +404,9 @@ class DeskproService {
 
   /**
    * Upload a file.
+   *
+   * @see https://support.deskpro.com/en-US/guides/developers/example-create-ticket
+   * @see https://start.deskpro.com/developers/api-docs/v2.html#post--api-v2-blobs
    */
   private function uploadFile($path) {
     $endpoint = '/blobs/temp';

--- a/web/modules/custom/hoeringsportal_deskpro/src/Service/HearingHelper.php
+++ b/web/modules/custom/hoeringsportal_deskpro/src/Service/HearingHelper.php
@@ -229,6 +229,8 @@ class HearingHelper {
       $response = $this->deskpro->createTicket($person, $data);
       $ticket = $response->getData();
 
+      // Reupload files for use in message.
+      $blobs = $this->deskpro->uploadFiles($files);
       $response = $this->deskpro->createMessage($ticket, $data, $blobs);
       $message = $response->getData();
 

--- a/web/modules/custom/hoeringsportal_project/hoeringsportal_project.services.yml
+++ b/web/modules/custom/hoeringsportal_project/hoeringsportal_project.services.yml
@@ -3,3 +3,5 @@ services:
     autowire: true
 
   Drupal\hoeringsportal_project\Hook\ProjectHooks:
+
+  Drupal\hoeringsportal_project\Helper\Helper:

--- a/web/modules/custom/hoeringsportal_project/src/Drush/Commands/DrushCommands.php
+++ b/web/modules/custom/hoeringsportal_project/src/Drush/Commands/DrushCommands.php
@@ -1,6 +1,6 @@
 <?php
 
-  namespace Drupal\hoeringsportal_project\Drush\Commands;
+namespace Drupal\hoeringsportal_project\Drush\Commands;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\hoeringsportal_project\Helper\Helper;
@@ -39,4 +39,5 @@ final class DrushCommands extends BaseDrushCommands {
     $output['notes'] = $this->helper->getTimelineNotes($project);
     $this->output->writeln('Done');
   }
+
 }

--- a/web/modules/custom/hoeringsportal_project/src/Drush/Commands/DrushCommands.php
+++ b/web/modules/custom/hoeringsportal_project/src/Drush/Commands/DrushCommands.php
@@ -25,7 +25,7 @@ final class DrushCommands extends BaseDrushCommands {
   }
 
   /**
-   * Updates state on courses.
+   * Get timeline content.
    *
    * @command hoeringsportal:project:test-timeline-content
    * @usage hoeringsportal:project:test-timeline-content
@@ -37,7 +37,14 @@ final class DrushCommands extends BaseDrushCommands {
     $project = $this->entityTypeManagerInterface->getStorage('node')->load($nid);
     $output['nodes'] = $this->helper->getTimelineNodes($project);
     $output['notes'] = $this->helper->getTimelineNotes($project);
-    $this->output->writeln('Done');
+    $this->output->writeln(' -- Nodes: --');
+    foreach ($output['nodes'] as $node) {
+      $this->output->writeln($node->getTitle() .'(' . $node->id() . ')');
+    }
+    $this->output->writeln(' -- Notes: --');
+    foreach ($output['notes'] as $note) {
+      $this->output->writeln($note->field_title->value);
+    }
   }
 
 }

--- a/web/modules/custom/hoeringsportal_project/src/Drush/Commands/DrushCommands.php
+++ b/web/modules/custom/hoeringsportal_project/src/Drush/Commands/DrushCommands.php
@@ -38,7 +38,7 @@ final class DrushCommands extends BaseDrushCommands {
     $output['notes'] = $this->helper->getTimelineNotes($project);
     $this->output->writeln(' -- Nodes: --');
     foreach ($output['nodes'] as $node) {
-      $this->output->writeln($node->getTitle() .'(' . $node->id() . ')');
+      $this->output->writeln($node->getTitle() . '(' . $node->id() . ')');
     }
     $this->output->writeln(' -- Notes: --');
     foreach ($output['notes'] as $note) {

--- a/web/modules/custom/hoeringsportal_project/src/Drush/Commands/DrushCommands.php
+++ b/web/modules/custom/hoeringsportal_project/src/Drush/Commands/DrushCommands.php
@@ -1,0 +1,42 @@
+<?php
+
+  namespace Drupal\hoeringsportal_project\Drush\Commands;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\hoeringsportal_project\Helper\Helper;
+use Drush\Attributes as CLI;
+use Drush\Commands\AutowireTrait;
+use Drush\Commands\DrushCommands as BaseDrushCommands;
+
+/**
+ * Custom drush commands for hoeringsportal_project.
+ */
+final class DrushCommands extends BaseDrushCommands {
+  use AutowireTrait;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    private readonly Helper $helper,
+    protected EntityTypeManagerInterface $entityTypeManagerInterface,
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * Updates state on courses.
+   *
+   * @command hoeringsportal:project:test-timeline-content
+   * @usage hoeringsportal:project:test-timeline-content
+   *   Update state for all courses.
+   */
+  #[CLI\Command(name: 'hoeringsportal:project:test-timeline-content')]
+  #[CLI\Argument(name: 'nid', description: 'Project node id')]
+  public function testTimelineContent($nid): void {
+    $project = $this->entityTypeManagerInterface->getStorage('node')->load($nid);
+    $output['nodes'] = $this->helper->getTimelineNodes($project);
+    $output['notes'] = $this->helper->getTimelineNotes($project);
+    $this->output->writeln('Done');
+  }
+}

--- a/web/modules/custom/hoeringsportal_project/src/Drush/Commands/DrushCommands.php
+++ b/web/modules/custom/hoeringsportal_project/src/Drush/Commands/DrushCommands.php
@@ -25,11 +25,10 @@ final class DrushCommands extends BaseDrushCommands {
   }
 
   /**
-   * Get timeline content.
+   * Show timeline content for specific project node.
    *
    * @command hoeringsportal:project:test-timeline-content
    * @usage hoeringsportal:project:test-timeline-content
-   *   Update state for all courses.
    */
   #[CLI\Command(name: 'hoeringsportal:project:test-timeline-content')]
   #[CLI\Argument(name: 'nid', description: 'Project node id')]

--- a/web/modules/custom/hoeringsportal_project/src/Helper/Helper.php
+++ b/web/modules/custom/hoeringsportal_project/src/Helper/Helper.php
@@ -44,7 +44,7 @@ class Helper {
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManagerInterface,
     protected UrlGeneratorInterface $urlGenerator,
-    LoggerChannelFactoryInterface $loggerFactory
+    LoggerChannelFactoryInterface $loggerFactory,
   ) {
     $this->logger = $loggerFactory->get('hoeringsportal_project');
   }
@@ -52,8 +52,8 @@ class Helper {
   /**
    * Get timeline nodes.
    *
-   * @param array $variables
-   *   A template variables array.
+   * @param \Drupal\node\Entity\Node|null $node
+   *   A node entity.
    *
    * @return array|null
    *   Array of node entities or NULL.
@@ -89,6 +89,7 @@ class Helper {
    * Get timeline notes.
    *
    * @param \Drupal\node\Entity\Node|null $node
+   *   A node entity.
    *
    * @return array|null
    *   Array of paragraph entities or NULL.
@@ -340,4 +341,5 @@ class Helper {
       default => NULL,
     };
   }
+
 }

--- a/web/modules/custom/hoeringsportal_project/src/Helper/Helper.php
+++ b/web/modules/custom/hoeringsportal_project/src/Helper/Helper.php
@@ -1,0 +1,343 @@
+<?php
+
+namespace Drupal\hoeringsportal_project\Helper;
+
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\DependencyInjection\AutowireTrait;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\file\Entity\File;
+use Drupal\hoeringsportal_dialogue\Helper\DialogueHelper;
+use Drupal\image\Entity\ImageStyle;
+use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
+use Drupal\paragraphs\ParagraphInterface;
+use Drupal\Core\Routing\UrlGeneratorInterface;
+
+/**
+ * Helper for project-related operations.
+ */
+class Helper {
+
+  use StringTranslationTrait;
+  use AutowireTrait;
+
+  public const string STATUS_COMPLETED = 'completed';
+  // Used for items whose start time and end time are on the same day and said
+  // day is today.
+  public const string STATUS_CURRENT = 'current';
+  // Used for items where "now" is between the item's start and end times.
+  public const string STATUS_IN_PROGRESS = 'in_progress';
+  public const string STATUS_NOTE = 'note';
+  public const string STATUS_UPCOMING = 'upcoming';
+
+  /**
+   * The logger channel.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected LoggerChannelInterface $logger;
+
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManagerInterface,
+    protected UrlGeneratorInterface $urlGenerator,
+    LoggerChannelFactoryInterface $loggerFactory
+  ) {
+    $this->logger = $loggerFactory->get('hoeringsportal_project');
+  }
+
+  /**
+   * Get timeline nodes.
+   *
+   * @param array $variables
+   *   A template variables array.
+   *
+   * @return array|null
+   *   Array of node entities or NULL.
+   */
+  public function getTimelineNodes(?Node $node) : ?array {
+    try {
+      $nodeStorage = $this->entityTypeManagerInterface->getStorage('node');
+
+      $referenceQuery = $nodeStorage->getQuery();
+      $dateFieldQuery = $referenceQuery->orConditionGroup()
+        ->exists('field_decision_date')
+        ->exists('field_start_date')
+        ->exists('field_last_meeting_time')
+        ->condition('type', DialogueHelper::DIALOGUE_TYPE, '=');
+
+      $referenceQuery->accessCheck();
+      $referenceQuery->exists('field_project_reference');
+      $referenceQuery->condition('field_project_reference', $node->id());
+      $referenceQuery->condition('status', 1);
+      $referenceQuery->condition('field_hide_in_timeline', FALSE);
+      $referenceQuery->condition($dateFieldQuery);
+      $references = $referenceQuery->execute();
+
+      return $nodeStorage->loadMultiple($references);
+    }
+    catch (\Exception $e) {
+      $this->logger->error('Error getting timeline nodes: @message', ['@message' => $e->getMessage()]);
+      return [];
+    }
+  }
+
+  /**
+   * Get timeline notes.
+   *
+   * @param \Drupal\node\Entity\Node|null $node
+   *
+   * @return array|null
+   *   Array of paragraph entities or NULL.
+   */
+  public function getTimelineNotes(?Node $node) : ?array {
+    if ($node->hasField('field_timeline')) {
+      /** @var \Drupal\Core\Field\EntityReferenceFieldItemListInterface $list */
+      $list = $node->get('field_timeline');
+
+      return $list->referencedEntities();
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Add a node as a timeline item.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node entity to add.
+   * @param \Drupal\Core\Datetime\DrupalDateTime $now
+   *   The current date and time.
+   *
+   * @return array
+   *   The timeline item array.
+   */
+  public function addNodeAsTimelineItem(NodeInterface $node, DrupalDateTime $now): array {
+    try {
+      [$startTime, $endTime] = $this->determineTimes($node);
+      if (!$startTime) {
+        return [];
+      }
+      $image = $this->determineImage($node)?->getFileUri();
+
+      return [
+        'id' => $node->id(),
+        'date' => $startTime->format('Y-m-d'),
+        'month' => $startTime->format('F Y'),
+        'title' => $node->getTitle(),
+        'subtitle' => $node->type->entity->label(),
+        'description' => $node->field_teaser->value,
+        'status' => $this->determineStatus($node, $startTime, $endTime, $now),
+        'image' => $image ? ImageStyle::load('responsive_medium_default')->buildUrl($image) : NULL,
+        'link' => $this->urlGenerator->generateFromRoute('entity.node.canonical', ['node' => $node->id()]),
+        'linkText' => $this->t('View <span>@type</span>', ['@type' => $node->type->entity->label()]),
+        'accentColor' => $this->determineAccentColor($node->bundle()),
+      ];
+    }
+    catch (\Exception $e) {
+      $this->logger->error('Error adding node as timeline item: @message', ['@message' => $e->getMessage()]);
+      return [];
+    }
+  }
+
+  /**
+   * Add a note as a timeline item.
+   *
+   * @param \Drupal\paragraphs\ParagraphInterface $paragraph
+   *   The paragraph entity to add.
+   * @param \Drupal\Core\Datetime\DrupalDateTime $now
+   *   The current date and time.
+   *
+   * @return array
+   *   The timeline item array.
+   */
+  public function addNoteAsTimelineItem(ParagraphInterface $paragraph, DrupalDateTime $now): array {
+    try {
+      $date = $paragraph->field_date->date;
+      if (!$date) {
+        return [];
+      }
+      $image = $paragraph?->field_paragraph_image?->entity?->field_itk_media_image_upload?->entity?->getFileUri();
+
+      return [
+        'id' => 'note-' . $paragraph->id(),
+        'date' => $date->format('Y-m-d'),
+        'month' => $date->format('F Y'),
+        'title' => $paragraph->field_title->value,
+        'subtitle' => $paragraph->field_subtitle->value,
+        'description' => $paragraph->field_note->value,
+        'status' => $this->determineStatus($paragraph, $date, $date, $now),
+        'image' => $image ? ImageStyle::load('responsive_medium_default')->buildUrl($image) : NULL,
+        'link' => $paragraph?->field_external_link?->uri ?? '',
+        'linkText' => $this->t('View more'),
+        'accentColor' => 'blue',
+      ];
+    }
+    catch (\Exception $e) {
+      $this->logger->error('Error adding note as timeline item: @message', ['@message' => $e->getMessage()]);
+      return [];
+    }
+  }
+
+  /**
+   * Add "today" timeline item.
+   *
+   * @param \Drupal\Core\Datetime\DrupalDateTime $now
+   *   The current date and time.
+   *
+   * @return array
+   *   The timeline item array.
+   */
+  public function addNowAsTimelineItem(DrupalDateTime $now): array {
+    return [
+      'id' => 'today',
+      'date' => $now->format('Y-m-d'),
+      'month' => $now->format('d-m-Y'),
+      'title' => $this->t('Project status'),
+      'subtitle' => NULL,
+      'description' => NULL,
+      'status' => self::STATUS_CURRENT,
+      'image' => NULL,
+      'link' => NULL,
+      'linkText' => NULL,
+      'is_today_marker' => TRUE,
+    ];
+  }
+
+  /**
+   * Determine start and end times for a timeline item.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node entity to extract the date from.
+   *
+   * @return array{
+   *   0: \Drupal\Core\Datetime\DrupalDateTime|null,
+   *   1: \Drupal\Core\Datetime\DrupalDateTime|null,
+   *   }
+   *   The determined start and end times if any.
+   */
+  private function determineTimes(NodeInterface $node): array {
+    try {
+      switch ($node->getType()) {
+        case 'course':
+        case 'event':
+          return [
+            DrupalDateTime::createFromFormat('Y-m-d\TH:i:s', $node->get('field_first_meeting_time')->value),
+            DrupalDateTime::createFromFormat('Y-m-d\TH:i:s', $node->get('field_last_meeting_time')->value),
+          ];
+
+        case 'public_meeting':
+          return [
+            DrupalDateTime::createFromFormat('Y-m-d\TH:i:s', $node->get('field_last_meeting_time')->value),
+            DrupalDateTime::createFromFormat('Y-m-d\TH:i:s', $node->get('field_last_meeting_time')->value),
+          ];
+
+        case 'decision':
+          return [
+            DrupalDateTime::createFromFormat('Y-m-d', $node->get('field_decision_date')->value),
+            DrupalDateTime::createFromFormat('Y-m-d', $node->get('field_decision_date')->value),
+          ];
+
+        case 'dialogue':
+          return [
+            DrupalDateTime::createFromTimestamp($node->getCreatedTime()),
+            DrupalDateTime::createFromTimestamp($node->getCreatedTime()),
+          ];
+
+        case 'hearing':
+          return [
+            DrupalDateTime::createFromFormat('Y-m-d\TH:i:s', $node->get('field_start_date')->value),
+            DrupalDateTime::createFromFormat('Y-m-d\TH:i:s', $node->get('field_reply_deadline')->value),
+          ];
+
+        default:
+          throw new \RuntimeException(sprintf('Unhandled node type: %s',
+            $node->getType()));
+      }
+    }
+    catch (\Exception $e) {
+      $this->logger->error('Error determining date for node @nid: @message', [
+        '@nid' => $node->id(),
+        '@message' => $e->getMessage(),
+      ]);
+      return [NULL, NULL];
+    }
+  }
+
+  /**
+   * Determine image for timeline item.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node entity to extract the image from.
+   *
+   * @return \Drupal\file\Entity\File|null
+   *   The file entity or NULL if no image found.
+   */
+  private function determineImage(NodeInterface $node): ?File {
+    try {
+      return match (TRUE) {
+        $node->hasField('field_media_image') => $node->field_media_image->entity->field_itk_media_image_upload->entity,
+        $node->hasField('field_media_image_single') => $node->field_media_image_single->entity->field_itk_media_image_upload->entity,
+        $node->hasField('field_top_images') => $node->field_top_images->entity->field_itk_media_image_upload->entity,
+        default => NULL,
+      };
+    }
+    catch (\Exception $e) {
+      $this->logger->error('Error determining image for node @nid: @message', [
+        '@nid' => $node->id(),
+        '@message' => $e->getMessage(),
+      ]);
+      return NULL;
+    }
+  }
+
+  /**
+   * Determine status of timeline item.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to determine status for.
+   * @param \Drupal\Core\Datetime\DrupalDateTime $startTime
+   *   The start time.
+   * @param \Drupal\Core\Datetime\DrupalDateTime $endTime
+   *   The end time.
+   * @param \Drupal\Core\Datetime\DrupalDateTime $now
+   *   The current date.
+   *
+   * @return string
+   *   The status (one ot the STATUS_… constants).
+   */
+  private function determineStatus(EntityInterface $entity, DrupalDateTime $startTime, DrupalDateTime $endTime, DrupalDateTime $now): string {
+    $startDay = $startTime->format('Y-m-d');
+    $endDay = $endTime->format('Y-m-d');
+    $today = $now->format('Y-m-d');
+
+    return match (TRUE) {
+      $startDay === $endDay && $endDay === $today => self::STATUS_CURRENT,
+      $startTime <= $now && $now <= $endTime => self::STATUS_IN_PROGRESS,
+      $startTime > $now => self::STATUS_UPCOMING,
+      $entity->getEntityTypeId() === 'node' => self::STATUS_COMPLETED,
+      $entity->getEntityTypeId() === 'paragraph' => self::STATUS_NOTE,
+      default => '',
+    };
+  }
+
+  /**
+   * Determine accent color based on content type.
+   *
+   * @param string $bundle
+   *   The entity bundle/type.
+   *
+   * @return string|null
+   *   The accent color (green, pink, blue) or NULL.
+   */
+  private function determineAccentColor(string $bundle): ?string {
+    return match ($bundle) {
+      'hearing', 'decision', 'dialogue' => 'green',
+      'course', 'public_meeting' => 'pink',
+      default => NULL,
+    };
+  }
+}

--- a/web/modules/custom/hoeringsportal_project/src/Hook/ProjectHooks.php
+++ b/web/modules/custom/hoeringsportal_project/src/Hook/ProjectHooks.php
@@ -4,6 +4,7 @@ namespace Drupal\hoeringsportal_project\Hook;
 
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -12,17 +13,15 @@ use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Routing\UrlGeneratorInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\file\Entity\File;
-use Drupal\hoeringsportal_dialogue\Helper\DialogueHelper;
-use Drupal\image\Entity\ImageStyle;
+use Drupal\hoeringsportal_project\Helper\Helper;
 use Drupal\node\NodeInterface;
-use Drupal\paragraphs\ParagraphInterface;
 
 /**
  * Hooks for project-related operations.
  */
 class ProjectHooks {
   use StringTranslationTrait;
+  use   AutowireTrait;
 
   public const string STATUS_COMPLETED = 'completed';
   // Used for items whose start time and end time are on the same day and said
@@ -44,6 +43,7 @@ class ProjectHooks {
     protected EntityTypeManagerInterface $entityTypeManagerInterface,
     protected UrlGeneratorInterface $urlGenerator,
     LoggerChannelFactoryInterface $loggerFactory,
+    protected Helper $helper
   ) {
     $this->logger = $loggerFactory->get('hoeringsportal_project');
   }
@@ -64,25 +64,25 @@ class ProjectHooks {
       $variables['timeline_items'] = [];
       $now = new DrupalDateTime();
 
-      $nodes = $this->getTimelineNodes($variables);
+      $nodes = $this->helper->getTimelineNodes($variables['node']);
 
       foreach ($nodes as $node) {
-        $item = $this->addNodeAsTimelineItem($node, $now);
+        $item = $this->helper->addNodeAsTimelineItem($node, $now);
         if (!empty($item)) {
           $variables['timeline_items'][] = $item;
         }
       }
 
-      $notes = $this->getTimelineNotes($variables);
+      $notes = $this->helper->getTimelineNotes($variables['node']);
 
       foreach ($notes as $note) {
-        $item = $this->addNoteAsTimelineItem($note, $now);
+        $item = $this->helper->addNoteAsTimelineItem($note, $now);
         if (!empty($item)) {
           $variables['timeline_items'][] = $item;
         }
       }
 
-      $variables['timeline_items'][] = $this->addNowAsTimelineItem($now);
+      $variables['timeline_items'][] = $this->helper->addNowAsTimelineItem($now);
       usort($variables['timeline_items'], static fn(array $a, array $b): int => $a['date'] <=> $b['date']);
 
       $variables['legend_items'] = [
@@ -167,293 +167,4 @@ class ProjectHooks {
       }
     }
   }
-
-  /**
-   * Get timeline nodes.
-   *
-   * @param array $variables
-   *   The template variables array.
-   *
-   * @return array|null
-   *   Array of node entities or NULL.
-   */
-  private function getTimelineNodes(array $variables) : ?array {
-    try {
-      $nodeStorage = $this->entityTypeManagerInterface->getStorage('node');
-
-      $referenceQuery = $nodeStorage->getQuery();
-      $dateFieldQuery = $referenceQuery->orConditionGroup()
-        ->exists('field_decision_date')
-        ->exists('field_start_date')
-        ->exists('field_last_meeting_time')
-        ->condition('type', DialogueHelper::DIALOGUE_TYPE, '=');
-
-      $referenceQuery->accessCheck();
-      $referenceQuery->exists('field_project_reference');
-      $referenceQuery->condition('field_project_reference', $variables['node']->id());
-      $referenceQuery->condition('status', 1);
-      $referenceQuery->condition('field_hide_in_timeline', FALSE);
-      $referenceQuery->condition($dateFieldQuery);
-      $references = $referenceQuery->execute();
-
-      return $nodeStorage->loadMultiple($references);
-    }
-    catch (\Exception $e) {
-      $this->logger->error('Error getting timeline nodes: @message', ['@message' => $e->getMessage()]);
-      return [];
-    }
-  }
-
-  /**
-   * Get timeline notes.
-   *
-   * @param array $variables
-   *   The template variables array.
-   *
-   * @return array|null
-   *   Array of paragraph entities or NULL.
-   */
-  private function getTimelineNotes(array $variables) : ?array {
-    $node = $variables['node'] ?? NULL;
-    if ($node instanceof NodeInterface && $node->hasField('field_timeline')) {
-      /** @var \Drupal\Core\Field\EntityReferenceFieldItemListInterface $list */
-      $list = $node->get('field_timeline');
-
-      return $list->referencedEntities();
-    }
-
-    return NULL;
-  }
-
-  /**
-   * Add node as timeline item.
-   *
-   * @param \Drupal\node\NodeInterface $node
-   *   The node entity to add.
-   * @param \Drupal\Core\Datetime\DrupalDateTime $now
-   *   The current date and time.
-   *
-   * @return array
-   *   The timeline item array.
-   */
-  private function addNodeAsTimelineItem(NodeInterface $node, DrupalDateTime $now): array {
-    try {
-      [$startTime, $endTime] = $this->determineTimes($node);
-      if (!$startTime) {
-        return [];
-      }
-      $image = $this->determineImage($node)?->getFileUri();
-
-      return [
-        'id' => $node->id(),
-        'date' => $startTime->format('Y-m-d'),
-        'month' => $startTime->format('F Y'),
-        'title' => $node->getTitle(),
-        'subtitle' => $node->type->entity->label(),
-        'description' => $node->field_teaser->value,
-        'status' => $this->determineStatus($node, $startTime, $endTime, $now),
-        'image' => $image ? ImageStyle::load('responsive_medium_default')->buildUrl($image) : NULL,
-        'link' => $this->urlGenerator->generateFromRoute('entity.node.canonical', ['node' => $node->id()]),
-        'linkText' => $this->t('View <span>@type</span>', ['@type' => $node->type->entity->label()]),
-        'accentColor' => $this->determineAccentColor($node->bundle()),
-      ];
-    }
-    catch (\Exception $e) {
-      $this->logger->error('Error adding node as timeline item: @message', ['@message' => $e->getMessage()]);
-      return [];
-    }
-  }
-
-  /**
-   * Add note as timeline item.
-   *
-   * @param \Drupal\paragraphs\ParagraphInterface $paragraph
-   *   The paragraph entity to add.
-   * @param \Drupal\Core\Datetime\DrupalDateTime $now
-   *   The current date and time.
-   *
-   * @return array
-   *   The timeline item array.
-   */
-  private function addNoteAsTimelineItem(ParagraphInterface $paragraph, DrupalDateTime $now): array {
-    try {
-      $date = $paragraph->field_date->date;
-      if (!$date) {
-        return [];
-      }
-      $image = $paragraph?->field_paragraph_image?->entity?->field_itk_media_image_upload?->entity?->getFileUri();
-
-      return [
-        'id' => 'note-' . $paragraph->id(),
-        'date' => $date->format('Y-m-d'),
-        'month' => $date->format('F Y'),
-        'title' => $paragraph->field_title->value,
-        'subtitle' => $paragraph->field_subtitle->value,
-        'description' => $paragraph->field_note->value,
-        'status' => $this->determineStatus($paragraph, $date, $date, $now),
-        'image' => $image ? ImageStyle::load('responsive_medium_default')->buildUrl($image) : NULL,
-        'link' => $paragraph?->field_external_link?->uri ?? '',
-        'linkText' => $this->t('View more'),
-        'accentColor' => 'blue',
-      ];
-    }
-    catch (\Exception $e) {
-      $this->logger->error('Error adding note as timeline item: @message', ['@message' => $e->getMessage()]);
-      return [];
-    }
-  }
-
-  /**
-   * Add "today" timeline item.
-   *
-   * @param \Drupal\Core\Datetime\DrupalDateTime $now
-   *   The current date and time.
-   *
-   * @return array
-   *   The timeline item array.
-   */
-  private function addNowAsTimelineItem(DrupalDateTime $now): array {
-    return [
-      'id' => 'today',
-      'date' => $now->format('Y-m-d'),
-      'month' => $now->format('d-m-Y'),
-      'title' => $this->t('Project status'),
-      'subtitle' => NULL,
-      'description' => NULL,
-      'status' => self::STATUS_CURRENT,
-      'image' => NULL,
-      'link' => NULL,
-      'linkText' => NULL,
-      'is_today_marker' => TRUE,
-    ];
-  }
-
-  /**
-   * Determine start and end times for a timeline item.
-   *
-   * @param \Drupal\node\NodeInterface $node
-   *   The node entity to extract the date from.
-   *
-   * @return array{
-   *   0: \Drupal\Core\Datetime\DrupalDateTime|null,
-   *   1: \Drupal\Core\Datetime\DrupalDateTime|null,
-   *   }
-   *   The determined start and end times if any.
-   */
-  private function determineTimes(NodeInterface $node): array {
-    try {
-      switch ($node->getType()) {
-        case 'course':
-        case 'event':
-          return [
-            $node->get('field_first_meeting_time')->date,
-            $node->get('field_last_meeting_time')->date,
-          ];
-
-        case 'decision':
-          return [
-            $node->get('field_decision_date')->date,
-            $node->get('field_decision_date')->date,
-          ];
-
-        case 'dialogue':
-          return [
-            DrupalDateTime::createFromTimestamp($node->getCreatedTime()),
-            DrupalDateTime::createFromTimestamp($node->getCreatedTime()),
-          ];
-
-        case 'hearing':
-          return [
-            $node->get('field_start_date')->date,
-            $node->get('field_reply_deadline')->date,
-          ];
-
-        default:
-          throw new \RuntimeException(sprintf('Unhandled node type: %s',
-            $node->getType()));
-      }
-    }
-    catch (\Exception $e) {
-      $this->logger->error('Error determining date for node @nid: @message', [
-        '@nid' => $node->id(),
-        '@message' => $e->getMessage(),
-      ]);
-      return [NULL, NULL];
-    }
-  }
-
-  /**
-   * Determine image for timeline item.
-   *
-   * @param \Drupal\node\NodeInterface $node
-   *   The node entity to extract the image from.
-   *
-   * @return \Drupal\file\Entity\File|null
-   *   The file entity or NULL if no image found.
-   */
-  private function determineImage(NodeInterface $node): ?File {
-    try {
-      return match (TRUE) {
-        $node->hasField('field_media_image') => $node->field_media_image->entity->field_itk_media_image_upload->entity,
-        $node->hasField('field_media_image_single') => $node->field_media_image_single->entity->field_itk_media_image_upload->entity,
-        $node->hasField('field_top_images') => $node->field_top_images->entity->field_itk_media_image_upload->entity,
-        default => NULL,
-      };
-    }
-    catch (\Exception $e) {
-      $this->logger->error('Error determining image for node @nid: @message', [
-        '@nid' => $node->id(),
-        '@message' => $e->getMessage(),
-      ]);
-      return NULL;
-    }
-  }
-
-  /**
-   * Determine status of timeline item.
-   *
-   * @param \Drupal\Core\Entity\EntityInterface $entity
-   *   The entity to determine status for.
-   * @param \Drupal\Core\Datetime\DrupalDateTime $startTime
-   *   The start time.
-   * @param \Drupal\Core\Datetime\DrupalDateTime $endTime
-   *   The end time.
-   * @param \Drupal\Core\Datetime\DrupalDateTime $now
-   *   The current date.
-   *
-   * @return string
-   *   The status (one ot the STATUS_… constants).
-   */
-  private function determineStatus(EntityInterface $entity, DrupalDateTime $startTime, DrupalDateTime $endTime, DrupalDateTime $now): string {
-    $startDay = $startTime->format('Y-m-d');
-    $endDay = $endTime->format('Y-m-d');
-    $today = $now->format('Y-m-d');
-
-    return match (TRUE) {
-      $startDay === $endDay && $endDay === $today => self::STATUS_CURRENT,
-      $startTime <= $now && $now <= $endTime => self::STATUS_IN_PROGRESS,
-      $startTime > $now => self::STATUS_UPCOMING,
-      $entity->getEntityTypeId() === 'node' => self::STATUS_COMPLETED,
-      $entity->getEntityTypeId() === 'paragraph' => self::STATUS_NOTE,
-      default => '',
-    };
-  }
-
-  /**
-   * Determine accent color based on content type.
-   *
-   * @param string $bundle
-   *   The entity bundle/type.
-   *
-   * @return string|null
-   *   The accent color (green, pink, blue) or NULL.
-   */
-  private function determineAccentColor(string $bundle): ?string {
-    return match ($bundle) {
-      'hearing', 'decision', 'dialogue' => 'green',
-      'course', 'public_meeting' => 'pink',
-      default => NULL,
-    };
-  }
-
 }

--- a/web/modules/custom/hoeringsportal_project/src/Hook/ProjectHooks.php
+++ b/web/modules/custom/hoeringsportal_project/src/Hook/ProjectHooks.php
@@ -21,7 +21,7 @@ use Drupal\node\NodeInterface;
  */
 class ProjectHooks {
   use StringTranslationTrait;
-  use   AutowireTrait;
+  use AutowireTrait;
 
   public const string STATUS_COMPLETED = 'completed';
   // Used for items whose start time and end time are on the same day and said
@@ -43,7 +43,7 @@ class ProjectHooks {
     protected EntityTypeManagerInterface $entityTypeManagerInterface,
     protected UrlGeneratorInterface $urlGenerator,
     LoggerChannelFactoryInterface $loggerFactory,
-    protected Helper $helper
+    protected Helper $helper,
   ) {
     $this->logger = $loggerFactory->get('hoeringsportal_project');
   }
@@ -167,4 +167,5 @@ class ProjectHooks {
       }
     }
   }
+
 }


### PR DESCRIPTION
Release 4.17.2

A hotfix and release in one go.

---

After creating a ticket and attaching files to a custom field (with ID 36), fields data looks like

```json
{
  "36": {
    "aliases": [],
    "value": [
      584442
    ],
    "detail": [
      {
        "content_type": "image/jpeg",
        "is_image": true,
        "blob_id": 584442,
        "blob_auth": "584442BAPKYTPHRXBHPDZ0",
        "blob_auth_id": "584442-584442BAPKYTPHRXBHPDZ0",
        "download_url": "https://deltagnu.aarhus.dk/file.php/584442BAPKYTPHRXBHPDZ0/picsum-photos-002.jpg?access_token=tjpjiu-dovlokauoo-0617073226358f5be3316cf2c71142902c5b1ee8",
        "filename": "picsum-photos-002.jpg",
        "filesize_readable": "18.68 KB",
        "is_temp": false
      }
    ]
  }
}
```

but shortly after, when fetching the data using the API, it looks like 

```json
{
  "36": {
    "aliases": [],
    "value": [
      584442
    ],
    "detail": [
      {
        "content_type": "image/jpeg",
        "is_image": true,
        "blob_id": 584442,
        "blob_auth": "584442BAPKYTPHRXBHPDZ0",
        "blob_auth_id": "584442-584442BAPKYTPHRXBHPDZ0",
        "download_url": "https://deltagnu.aarhus.dk/file.php/584442BAPKYTPHRXBHPDZ0/picsum-photos-002.jpg?access_token=tjpjiu-dovlokauoo-0617073226358f5be3316cf2c71142902c5b1ee8",
        "filename": "picsum-photos-002.jpg",
        "filesize_readable": "18.68 KB",
        "is_temp": true
      }
    ]
  }
}
```

Notice that `is_temp` has changed from `false` to `true`. Deskpro removes a file that is temp(orary) after a while.

The reason for the file becoming temporary seems to be that we use the same files (blobs) for both the ticket and the message (on the ticket). Uploading the files twice to prevent reusing blobs seems to resolve the issue with files being marked as temporary.